### PR TITLE
Add verifiable AI reasoning cookbook (Grok + xProof)

### DIFF
--- a/examples/verifiable_ai_reasoning/guide.ipynb
+++ b/examples/verifiable_ai_reasoning/guide.ipynb
@@ -1,0 +1,463 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Verifiable AI Reasoning with Grok + xProof\n",
+        "\n",
+        "Author: Jason Kensei\n",
+        "\n",
+        "---\n",
+        "\n",
+        "**What this cookbook demonstrates:** How to make Grok's reasoning cryptographically verifiable by anchoring decisions on-chain *before* output generation. Every Grok response gets a tamper-proof timestamp and hash — verifiable by anyone, irrefutable by design.\n",
+        "\n",
+        "**Why it matters:** LLMs can say anything. xProof turns Grok outputs into verifiable artifacts — the reasoning hash is anchored on MultiversX blockchain before the output is delivered. This creates a 4W audit trail:\n",
+        "- **WHO** — Grok (model identity, version)\n",
+        "- **WHAT** — The output content hash\n",
+        "- **WHEN** — Blockchain timestamp (immutable)\n",
+        "- **WHY** — The reasoning/prompt hash anchored before generation"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Setup\n",
+        "\n",
+        "You'll need:\n",
+        "1. An xAI API key from [console.x.ai](https://console.x.ai)\n",
+        "2. An xProof API key (free — 10 certifications included, no wallet needed)\n",
+        "\n",
+        "### Get your free xProof API key\n",
+        "\n",
+        "```bash\n",
+        "curl -X POST https://xproof.app/api/agent/register \\\n",
+        "  -H \"Content-Type: application/json\" \\\n",
+        "  -d '{\"agent_name\": \"grok-cookbook-demo\"}'\n",
+        "```\n",
+        "\n",
+        "This returns an API key with 10 free certifications. No wallet or payment required."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "%pip install openai requests --quiet"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import hashlib\n",
+        "import json\n",
+        "import time\n",
+        "import requests\n",
+        "from openai import OpenAI\n",
+        "\n",
+        "XAI_API_KEY = \"\"  # paste your xAI API key here\n",
+        "XPROOF_API_KEY = \"\"  # paste your xProof API key here\n",
+        "XPROOF_BASE = \"https://xproof.app\"\n",
+        "\n",
+        "client = OpenAI(\n",
+        "    api_key=XAI_API_KEY,\n",
+        "    base_url=\"https://api.x.ai/v1\",\n",
+        ")"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Helper Functions\n",
+        "\n",
+        "Two utilities:\n",
+        "1. `sha256_hash` — deterministic content hashing\n",
+        "2. `certify_on_xproof` — anchors a hash on MultiversX via xProof API"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "def sha256_hash(content: str) -> str:\n",
+        "    \"\"\"Generate SHA-256 hash of content.\"\"\"\n",
+        "    return hashlib.sha256(content.encode(\"utf-8\")).hexdigest()\n",
+        "\n",
+        "\n",
+        "def certify_on_xproof(file_hash: str, filename: str, metadata: dict) -> dict:\n",
+        "    \"\"\"Certify a hash on xProof (MultiversX blockchain anchoring).\"\"\"\n",
+        "    response = requests.post(\n",
+        "        f\"{XPROOF_BASE}/api/proof\",\n",
+        "        headers={\n",
+        "            \"Content-Type\": \"application/json\",\n",
+        "            \"x-api-key\": XPROOF_API_KEY,\n",
+        "        },\n",
+        "        json={\n",
+        "            \"fileHash\": file_hash,\n",
+        "            \"fileName\": filename,\n",
+        "            \"metadata\": metadata,\n",
+        "        },\n",
+        "    )\n",
+        "    response.raise_for_status()\n",
+        "    return response.json()"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 1: Anchor the WHY (Intent) Before Generation\n",
+        "\n",
+        "This is the key innovation. Before asking Grok to generate anything, we hash the prompt/intent and anchor it on-chain. This proves the reasoning existed *before* the output — not fabricated after the fact.\n",
+        "\n",
+        "The `action_type: \"reason\"` tag in metadata marks this as a pre-execution anchor (WHY layer)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "prompt = \"Analyze the current state of AI agent accountability. What are the key gaps in verifying that an AI agent did what it claims to have done?\"\n",
+        "\n",
+        "prompt_hash = sha256_hash(prompt)\n",
+        "print(f\"Prompt hash: {prompt_hash[:16]}...\")\n",
+        "\n",
+        "why_proof = certify_on_xproof(\n",
+        "    file_hash=prompt_hash,\n",
+        "    filename=\"grok-reasoning-intent.txt\",\n",
+        "    metadata={\n",
+        "        \"xai_agent_id\": \"grok-cookbook-demo\",\n",
+        "        \"xai_model\": \"grok-3\",\n",
+        "        \"action_type\": \"reason\",\n",
+        "        \"stage\": \"pre_execution\",\n",
+        "        \"prompt_hash\": prompt_hash,\n",
+        "    },\n",
+        ")\n",
+        "\n",
+        "print(f\"WHY proof anchored: {why_proof['id']}\")\n",
+        "print(f\"Verify: {XPROOF_BASE}/proof/{why_proof['id']}\")"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 2: Generate with Grok\n",
+        "\n",
+        "Now we call Grok. The prompt hash is already anchored on MultiversX — whatever Grok outputs, we can prove the intent preceded it."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "completion = client.chat.completions.create(\n",
+        "    model=\"grok-3\",\n",
+        "    messages=[\n",
+        "        {\n",
+        "            \"role\": \"system\",\n",
+        "            \"content\": \"You are a precise analyst. Give structured, evidence-based answers.\",\n",
+        "        },\n",
+        "        {\"role\": \"user\", \"content\": prompt},\n",
+        "    ],\n",
+        ")\n",
+        "\n",
+        "grok_output = completion.choices[0].message.content\n",
+        "grok_model = completion.model\n",
+        "print(f\"Model: {grok_model}\")\n",
+        "print(f\"Output length: {len(grok_output)} chars\")\n",
+        "print(f\"\\n{grok_output[:500]}...\")"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 3: Anchor the WHAT (Output) After Generation\n",
+        "\n",
+        "Now we hash and anchor the actual output. The metadata links back to the WHY proof via `prompt_hash`, creating a verifiable chain:\n",
+        "\n",
+        "```\n",
+        "WHY (prompt hash, anchored BEFORE) → Grok generation → WHAT (output hash, anchored AFTER)\n",
+        "```\n",
+        "\n",
+        "Anyone can verify that the intent existed before the output by checking the blockchain timestamps of both proofs."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "output_hash = sha256_hash(grok_output)\n",
+        "print(f\"Output hash: {output_hash[:16]}...\")\n",
+        "\n",
+        "what_proof = certify_on_xproof(\n",
+        "    file_hash=output_hash,\n",
+        "    filename=\"grok-analysis-output.txt\",\n",
+        "    metadata={\n",
+        "        \"xai_agent_id\": \"grok-cookbook-demo\",\n",
+        "        \"xai_model\": grok_model,\n",
+        "        \"action_type\": \"generate\",\n",
+        "        \"stage\": \"post_execution\",\n",
+        "        \"prompt_hash\": prompt_hash,\n",
+        "        \"content_hash\": output_hash,\n",
+        "    },\n",
+        ")\n",
+        "\n",
+        "print(f\"WHAT proof anchored: {what_proof['id']}\")\n",
+        "print(f\"Verify: {XPROOF_BASE}/proof/{what_proof['id']}\")"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 4: Verify the Full 4W Audit Trail\n",
+        "\n",
+        "The xProof xAI endpoint reconstructs the full picture — WHO (Grok), WHAT (output hash), WHEN (blockchain timestamps), WHY (prompt hash anchored before generation)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "verification = requests.get(\n",
+        "    f\"{XPROOF_BASE}/api/xai/grok-cookbook-demo\"\n",
+        ").json()\n",
+        "\n",
+        "print(json.dumps(verification, indent=2))"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 5: Investigate with Incident Report\n",
+        "\n",
+        "For any proof, you can pull the full incident report — the complete audit trail reconstruction showing the WHY→WHAT chain, timestamps, and verdict.\n",
+        "\n",
+        "This is the same investigation tool that autonomous agents use to audit each other."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "xai_data = requests.get(f\"{XPROOF_BASE}/api/xai/grok-cookbook-demo\").json()\n",
+        "\n",
+        "if xai_data.get(\"xproof\") and xai_data[\"xproof\"].get(\"wallet\"):\n",
+        "    wallet = xai_data[\"xproof\"][\"wallet\"]\n",
+        "    proof_id = what_proof[\"id\"]\n",
+        "    incident_url = f\"{XPROOF_BASE}/incident/{wallet}/{proof_id}\"\n",
+        "    print(f\"Full incident report: {incident_url}\")\n",
+        "    print(f\"\\nThis page shows:\")\n",
+        "    print(f\"  - Verdict (clean/anomaly/incomplete)\")\n",
+        "    print(f\"  - WHO: agent identity + trust score\")\n",
+        "    print(f\"  - WHY proof: prompt hash anchored BEFORE generation\")\n",
+        "    print(f\"  - WHAT proof: output hash anchored AFTER generation\")\n",
+        "    print(f\"  - Timeline with blockchain-verified timestamps\")\n",
+        "else:\n",
+        "    print(\"Run steps 1-3 first to create linked proofs.\")"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## How It Works Under the Hood\n",
+        "\n",
+        "```\n",
+        "┌─────────────┐     ┌──────────┐     ┌───────────────┐\n",
+        "│  Your App    │     │  Grok    │     │   xProof      │\n",
+        "│              │     │  API     │     │   (MultiversX) │\n",
+        "└──────┬───────┘     └────┬─────┘     └───────┬───────┘\n",
+        "       │                  │                   │\n",
+        "       │  1. Hash prompt  │                   │\n",
+        "       │──────────────────────────────────────>│\n",
+        "       │              WHY anchored on-chain   │\n",
+        "       │<─────────────────────────────────────│\n",
+        "       │                  │                   │\n",
+        "       │  2. Send prompt  │                   │\n",
+        "       │─────────────────>│                   │\n",
+        "       │    Grok output   │                   │\n",
+        "       │<─────────────────│                   │\n",
+        "       │                  │                   │\n",
+        "       │  3. Hash output  │                   │\n",
+        "       │──────────────────────────────────────>│\n",
+        "       │             WHAT anchored on-chain   │\n",
+        "       │<─────────────────────────────────────│\n",
+        "       │                  │                   │\n",
+        "       │  4. Anyone can verify:               │\n",
+        "       │     WHY timestamp < WHAT timestamp   │\n",
+        "       │     = intent preceded output          │\n",
+        "```\n",
+        "\n",
+        "### Key Properties\n",
+        "\n",
+        "- **Tamper-proof**: Hashes are anchored on MultiversX blockchain — can't be altered retroactively\n",
+        "- **Timestamped**: Blockchain provides immutable ordering — WHY always provably before WHAT\n",
+        "- **Public**: Anyone can verify via `GET /api/xai/{agent_id}` — no special access needed\n",
+        "- **Machine-readable**: The API returns structured JSON for automated verification\n",
+        "- **Free to start**: 10 free certifications, then $0.05/proof via USDC on Base (x402 protocol)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Production Integration Pattern\n",
+        "\n",
+        "For production agents, wrap the pattern into a reusable function:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "def verified_grok_call(\n",
+        "    prompt: str,\n",
+        "    agent_id: str = \"my-grok-agent\",\n",
+        "    model: str = \"grok-3\",\n",
+        "    system_prompt: str = \"You are a helpful assistant.\",\n",
+        ") -> dict:\n",
+        "    \"\"\"Make a Grok API call with full xProof verification.\n",
+        "\n",
+        "    Returns the Grok output plus WHY and WHAT proof IDs\n",
+        "    for complete audit trail reconstruction.\n",
+        "    \"\"\"\n",
+        "    prompt_hash = sha256_hash(prompt)\n",
+        "\n",
+        "    why_proof = certify_on_xproof(\n",
+        "        file_hash=prompt_hash,\n",
+        "        filename=f\"{agent_id}-intent.txt\",\n",
+        "        metadata={\n",
+        "            \"xai_agent_id\": agent_id,\n",
+        "            \"xai_model\": model,\n",
+        "            \"action_type\": \"reason\",\n",
+        "            \"stage\": \"pre_execution\",\n",
+        "            \"prompt_hash\": prompt_hash,\n",
+        "        },\n",
+        "    )\n",
+        "\n",
+        "    completion = client.chat.completions.create(\n",
+        "        model=model,\n",
+        "        messages=[\n",
+        "            {\"role\": \"system\", \"content\": system_prompt},\n",
+        "            {\"role\": \"user\", \"content\": prompt},\n",
+        "        ],\n",
+        "    )\n",
+        "\n",
+        "    output = completion.choices[0].message.content\n",
+        "    output_hash = sha256_hash(output)\n",
+        "\n",
+        "    what_proof = certify_on_xproof(\n",
+        "        file_hash=output_hash,\n",
+        "        filename=f\"{agent_id}-output.txt\",\n",
+        "        metadata={\n",
+        "            \"xai_agent_id\": agent_id,\n",
+        "            \"xai_model\": completion.model,\n",
+        "            \"action_type\": \"generate\",\n",
+        "            \"stage\": \"post_execution\",\n",
+        "            \"prompt_hash\": prompt_hash,\n",
+        "            \"content_hash\": output_hash,\n",
+        "        },\n",
+        "    )\n",
+        "\n",
+        "    return {\n",
+        "        \"output\": output,\n",
+        "        \"model\": completion.model,\n",
+        "        \"why_proof_id\": why_proof[\"id\"],\n",
+        "        \"what_proof_id\": what_proof[\"id\"],\n",
+        "        \"verify_url\": f\"{XPROOF_BASE}/api/xai/{agent_id}\",\n",
+        "        \"incident_report\": f\"{XPROOF_BASE}/incident/{{wallet}}/{what_proof['id']}\",\n",
+        "    }"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "result = verified_grok_call(\n",
+        "    prompt=\"What are the three most important properties a trust score for AI agents should have?\",\n",
+        "    agent_id=\"grok-cookbook-demo\",\n",
+        "    model=\"grok-3\",\n",
+        ")\n",
+        "\n",
+        "print(f\"WHY proof: {result['why_proof_id']}\")\n",
+        "print(f\"WHAT proof: {result['what_proof_id']}\")\n",
+        "print(f\"Verify agent: {result['verify_url']}\")\n",
+        "print(f\"\\nGrok output:\\n{result['output'][:500]}...\")"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Resources\n",
+        "\n",
+        "- [xProof API Documentation](https://xproof.app/docs)\n",
+        "- [xProof Machine-Readable Spec](https://xproof.app/.well-known/xproof.md)\n",
+        "- [xAI/Grok Integration Endpoint](https://xproof.app/api/xai/grok-cookbook-demo)\n",
+        "- [Agent Proof Standard](https://xproof.app/api/standard/spec) — open, stack-agnostic proof format\n",
+        "- [xProof on GitHub](https://github.com/jasonxkensei/xProof)\n",
+        "\n",
+        "### Pricing\n",
+        "\n",
+        "| Method | Cost | Details |\n",
+        "|--------|------|--------|\n",
+        "| Free trial | $0 | 10 certifications, no wallet needed |\n",
+        "| x402 (USDC on Base) | $0.05/proof | Pay per request, no account needed |\n",
+        "| API key | $0.05/proof | Prepaid credits via USDC on Base |\n",
+        "\n",
+        "### x402 Payment (No Account Required)\n",
+        "\n",
+        "Agents can also pay per-request with USDC on Base — no registration needed:\n",
+        "\n",
+        "```bash\n",
+        "# Request without auth returns 402 with payment requirements\n",
+        "curl -X POST https://xproof.app/api/proof \\\n",
+        "  -H \"Content-Type: application/json\" \\\n",
+        "  -d '{\"fileHash\": \"abc...\", \"fileName\": \"test.txt\"}'\n",
+        "\n",
+        "# Response: {\"x402Version\": 1, \"accepts\": [{\"price\": \"$0.05\", \"network\": \"eip155:8453\", ...}]}\n",
+        "```"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.11.0"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 4
+}


### PR DESCRIPTION
### What

A cookbook showing how to make Grok's reasoning cryptographically verifiable using xProof. The pattern anchors the prompt hash on MultiversX blockchain BEFORE calling Grok, then anchors the output hash AFTER — creating an immutable, publicly verifiable audit trail.

### Why

AI agents making decisions need accountability. This cookbook demonstrates a pattern where every Grok API call gets:
- **Tamper-proof timestamps** — blockchain ordering proves intent preceded output
- **Public verification** — anyone can check via `GET /api/xai/{agent_id}`
- **Machine-readable audit trail** — structured JSON for automated verification
- **Incident investigation** — full 4W reconstruction (WHO/WHAT/WHEN/WHY) for any proof

### What's included

- Step-by-step notebook: hash prompt → anchor WHY → call Grok → anchor WHAT → verify
- Production-ready `verified_grok_call()` wrapper function
- Architecture diagram showing the verification flow
- Links to live API endpoints and documentation

### Dependencies

- `openai` (already used in existing cookbooks)
- `requests` (standard library-adjacent)

### Checklist

- [x] All cells run end-to-end with valid API keys
- [x] Added to registry.yaml
- [x] Uses clear, descriptive cell titles
- [x] Python in code cells, explanations in markdown cells
- [x] Minimal dependencies
