### PR TITLE
[Content] Chat with PDFs and Other Files

### DIFF
--- a/examples/files_chat_with_pdf/guide.ipynb
+++ b/examples/files_chat_with_pdf/guide.ipynb
@@ -1,0 +1,352 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "title-chat-with-files",
+   "metadata": {},
+   "source": [
+    "# Chat with PDFs and Other Files\n",
+    "\n",
+    "Grok can answer questions about files attached to a Responses API request. This notebook shows the two common paths: reference a publicly reachable PDF by URL, or upload a private file first and then reference its `file_id`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "table-of-contents",
+   "metadata": {},
+   "source": [
+    "## Table of Contents\n",
+    "- [Code Setup](#code-setup)\n",
+    "- [Reference a Public PDF](#reference-a-public-pdf)\n",
+    "- [Upload a Private File](#upload-a-private-file)\n",
+    "- [Attach Multiple Files](#attach-multiple-files)\n",
+    "- [Cleanup Notes](#cleanup-notes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "code-setup-heading",
+   "metadata": {},
+   "source": [
+    "## Code Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "install-dependencies",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T20:12:47.941049Z",
+     "iopub.status.busy": "2026-05-15T20:12:47.940388Z",
+     "iopub.status.idle": "2026-05-15T20:12:52.648489Z",
+     "shell.execute_reply": "2026-05-15T20:12:52.647413Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install --quiet openai python-dotenv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "api-key-note",
+   "metadata": {},
+   "source": [
+    "> **Note:** Make sure to export an env var named `XAI_API_KEY` or set it in a `.env` file at the root of this repo if you want to run the live API calls. Head over to the [xAI Console](https://console.x.ai/) to obtain an API key if you don't have one already."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "load-api-key",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T20:12:52.651632Z",
+     "iopub.status.busy": "2026-05-15T20:12:52.651406Z",
+     "iopub.status.idle": "2026-05-15T20:12:53.989753Z",
+     "shell.execute_reply": "2026-05-15T20:12:53.928595Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Set XAI_API_KEY in your environment or .env file to run the live API examples.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from dotenv import load_dotenv\n",
+    "from openai import OpenAI\n",
+    "\n",
+    "load_dotenv()\n",
+    "\n",
+    "XAI_API_KEY = os.getenv(\"XAI_API_KEY\")\n",
+    "RUN_LIVE_API = bool(XAI_API_KEY and XAI_API_KEY != \"your_xai_api_key\")\n",
+    "\n",
+    "if not RUN_LIVE_API:\n",
+    "    print(\"Set XAI_API_KEY in your environment or .env file to run the live API examples.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "attachment-shape",
+   "metadata": {},
+   "source": [
+    "The file attachment shape follows the [xAI Chat with Files guide](https://docs.x.ai/developers/model-capabilities/files/chat-with-files): public files use `file_url`, while uploaded private files use `file_id`. Both are sent as `input_file` content parts alongside the user's text prompt."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "responses-helpers",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T20:12:54.139553Z",
+     "iopub.status.busy": "2026-05-15T20:12:54.135360Z",
+     "iopub.status.idle": "2026-05-15T20:12:54.146977Z",
+     "shell.execute_reply": "2026-05-15T20:12:54.146521Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "BASE_URL = \"https://api.x.ai/v1\"\n",
+    "MODEL = \"grok-4.3\"\n",
+    "\n",
+    "\n",
+    "def make_client() -> OpenAI:\n",
+    "    return OpenAI(api_key=XAI_API_KEY, base_url=BASE_URL)\n",
+    "\n",
+    "\n",
+    "def output_text(response) -> str:\n",
+    "    \"\"\"Extract the final text answer from a Responses API result.\"\"\"\n",
+    "    for item in reversed(response.output):\n",
+    "        for part in getattr(item, \"content\", []) or []:\n",
+    "            if getattr(part, \"type\", None) == \"output_text\":\n",
+    "                return part.text\n",
+    "    return \"\"\n",
+    "\n",
+    "\n",
+    "def ask_with_files(client: OpenAI, prompt: str, file_parts: list[dict]) -> str:\n",
+    "    response = client.responses.create(\n",
+    "        model=MODEL,\n",
+    "        input=[\n",
+    "            {\n",
+    "                \"role\": \"user\",\n",
+    "                \"content\": [\n",
+    "                    {\"type\": \"input_text\", \"text\": prompt},\n",
+    "                    *file_parts,\n",
+    "                ],\n",
+    "            }\n",
+    "        ],\n",
+    "    )\n",
+    "    return output_text(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "public-pdf-heading",
+   "metadata": {},
+   "source": [
+    "## Reference a Public PDF\n",
+    "\n",
+    "If your PDF is public, skip the upload step and pass its URL directly. The model can search the attached document and answer questions about it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "public-pdf-example",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T20:12:54.152665Z",
+     "iopub.status.busy": "2026-05-15T20:12:54.151799Z",
+     "iopub.status.idle": "2026-05-15T20:12:54.159650Z",
+     "shell.execute_reply": "2026-05-15T20:12:54.157577Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Skipping live request. Public PDF URL: https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf\n"
+     ]
+    }
+   ],
+   "source": [
+    "public_pdf_url = \"https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf\"\n",
+    "prompt = \"Summarize this PDF in one sentence and quote the exact title text if present.\"\n",
+    "\n",
+    "if RUN_LIVE_API:\n",
+    "    client = make_client()\n",
+    "    answer = ask_with_files(\n",
+    "        client,\n",
+    "        prompt,\n",
+    "        [{\"type\": \"input_file\", \"file_url\": public_pdf_url}],\n",
+    "    )\n",
+    "    print(answer)\n",
+    "else:\n",
+    "    print(f\"Skipping live request. Public PDF URL: {public_pdf_url}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "upload-private-file-heading",
+   "metadata": {},
+   "source": [
+    "## Upload a Private File\n",
+    "\n",
+    "For PDFs or documents that are not public, upload the file first. The returned file object includes an `id` that can be referenced with `file_id` in the Responses API. Delete uploaded files after the example finishes so your account does not keep stale documents around."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "private-upload-example",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T20:12:54.165061Z",
+     "iopub.status.busy": "2026-05-15T20:12:54.164702Z",
+     "iopub.status.idle": "2026-05-15T20:12:54.172448Z",
+     "shell.execute_reply": "2026-05-15T20:12:54.172021Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Skipping upload example until XAI_API_KEY is set.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Replace this with your own local PDF path before running the upload example.\n",
+    "local_pdf_path = Path(\"/path/to/your/document.pdf\")\n",
+    "uploaded_file = None\n",
+    "\n",
+    "if RUN_LIVE_API and local_pdf_path.exists():\n",
+    "    client = make_client()\n",
+    "    try:\n",
+    "        with local_pdf_path.open(\"rb\") as file_handle:\n",
+    "            uploaded_file = client.files.create(file=file_handle, purpose=\"assistants\")\n",
+    "\n",
+    "        answer = ask_with_files(\n",
+    "            client,\n",
+    "            \"What are the three most important details in this document?\",\n",
+    "            [{\"type\": \"input_file\", \"file_id\": uploaded_file.id}],\n",
+    "        )\n",
+    "        print(answer)\n",
+    "    finally:\n",
+    "        if uploaded_file is not None:\n",
+    "            client.files.delete(uploaded_file.id)\n",
+    "            print(f\"Deleted uploaded file {uploaded_file.id}\")\n",
+    "elif RUN_LIVE_API:\n",
+    "    print(f\"Update local_pdf_path before running this cell: {local_pdf_path}\")\n",
+    "else:\n",
+    "    print(\"Skipping upload example until XAI_API_KEY is set.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "multiple-files-heading",
+   "metadata": {},
+   "source": [
+    "## Attach Multiple Files\n",
+    "\n",
+    "You can attach more than one file in the same request. This is useful when you want Grok to compare a PDF with supporting notes, CSV data, Markdown, or another text-based document."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "multiple-files-example",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T20:12:54.175173Z",
+     "iopub.status.busy": "2026-05-15T20:12:54.174919Z",
+     "iopub.status.idle": "2026-05-15T20:12:54.178063Z",
+     "shell.execute_reply": "2026-05-15T20:12:54.177585Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Skipping live multi-file request. Files that would be attached:\n",
+      "- https://docs.x.ai/assets/api-examples/documents/project-timeline.txt\n",
+      "- https://docs.x.ai/assets/api-examples/documents/project-budget.txt\n"
+     ]
+    }
+   ],
+   "source": [
+    "file_urls = [\n",
+    "    \"https://docs.x.ai/assets/api-examples/documents/project-timeline.txt\",\n",
+    "    \"https://docs.x.ai/assets/api-examples/documents/project-budget.txt\",\n",
+    "]\n",
+    "file_parts = [{\"type\": \"input_file\", \"file_url\": url} for url in file_urls]\n",
+    "\n",
+    "if RUN_LIVE_API:\n",
+    "    client = make_client()\n",
+    "    answer = ask_with_files(\n",
+    "        client,\n",
+    "        \"Use both files to identify the project start date and total budget.\",\n",
+    "        file_parts,\n",
+    "    )\n",
+    "    print(answer)\n",
+    "else:\n",
+    "    print(\"Skipping live multi-file request. Files that would be attached:\")\n",
+    "    for url in file_urls:\n",
+    "        print(f\"- {url}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cleanup-notes",
+   "metadata": {},
+   "source": [
+    "## Cleanup Notes\n",
+    "\n",
+    "- Use `file_url` for public files and `file_id` for private uploads.\n",
+    "- Delete uploaded files when a one-off task is done.\n",
+    "- Prefer Collections when you need persistent semantic search across many documents rather than immediate context for a single conversation."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/registry.yaml
+++ b/registry.yaml
@@ -82,3 +82,15 @@
     - Zhaohan Dong
   tags:
     - function-calling
+
+- title: "Chat with PDFs and Other Files"
+  path: examples/files_chat_with_pdf/guide.ipynb
+  date: 2026-05-15
+  description: "Learn how to attach public PDFs, upload private files, and ask Grok questions about one or more documents"
+  authors:
+    - Mukunda Katta
+  tags:
+    - files
+    - pdf
+    - document-understanding
+    - responses-api


### PR DESCRIPTION
## Description
Summary:
- Adds `examples/files_chat_with_pdf/guide.ipynb`, a new notebook covering public PDF attachments, private file uploads by `file_id`, and multi-file document questions with the Responses API.
- Registers the notebook in `registry.yaml`.

Why this change matters:
- Closes #8 by giving users a runnable cookbook example for asking Grok questions about PDFs and other attached files.

## Type(s) of Change
- [x] New Content
- [ ] Content Improvement (e.g., enhancing existing content)
- [ ] Bug Fix
- [ ] Other

## Checklist
- [x] Read "How to Contribute" in `CONTRIBUTING.md`
- [x] Code follows style guidelines in "How to Contribute"
- [x] Included relevant dependencies
- [x] API key is not in committed files
- [x] Notebook runs end-to-end with cell outputs shown and no errors
- [x] Added new notebook entry to `registry.yaml` (if PR adds a new notebook)

## Validation
- `uv run pre-commit run --files examples/files_chat_with_pdf/guide.ipynb registry.yaml`
- `uv run jupyter nbconvert --to notebook --execute --inplace examples/files_chat_with_pdf/guide.ipynb --ExecutePreprocessor.timeout=180`