### PR TITLE
[Content] Human Sign-off for Irreversible Tool Calls

### DIFF
--- a/examples/human_in_the_loop_signoff/guide.ipynb
+++ b/examples/human_in_the_loop_signoff/guide.ipynb
@@ -2,99 +2,432 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "39385fdd",
    "metadata": {},
-   "source": "# Human Sign-off for Irreversible Tool Calls\n\nGrok's function calling lets an agent *act* — look things up, call APIs, move data. For most calls that's exactly what you want. But some actions are **irreversible**: sending a payment, changing a payout account, deleting records, deploying code. For those you often want a **named human to approve before the action runs** — without slowing down everything else.\n\nThis cookbook adds a minimal human-in-the-loop step on top of [function calling](../function_calling_101/guide.ipynb):\n\n1. **Classify** each tool call — most are low-risk and run immediately.\n2. **Route** irreversible ones through an approval step (`allow` / `signoff_required` / `deny`).\n3. **Execute** only once a human has approved.\n\nWe use a tiny local policy so the whole notebook runs with just your xAI API key. The last section shows how to take it to production."
+   "source": [
+    "# Human Sign-off for Irreversible Tool Calls\n",
+    "\n",
+    "Grok's function calling lets an agent *act* — look things up, call APIs, move data. For most calls that's exactly what you want. But some actions are **irreversible**: sending a payment, changing a payout account, deleting records, deploying code. For those you often want a **named human to approve before the action runs** — without slowing down everything else.\n",
+    "\n",
+    "This cookbook adds a minimal human-in-the-loop step on top of [function calling](../function_calling_101/guide.ipynb):\n",
+    "\n",
+    "1. **Classify** each tool call — most are low-risk and run immediately.\n",
+    "2. **Route** irreversible ones through an approval step (`allow` / `signoff_required` / `deny`).\n",
+    "3. **Execute** only once a human has approved.\n",
+    "\n",
+    "We use a tiny local policy so the whole notebook runs with just your xAI API key. The last section shows how to take it to production."
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "4d4ff18e",
    "metadata": {},
-   "source": "## Setup\n\nGrok is OpenAI-compatible, so we use the same `openai` client and `chat.completions` API as `function_calling_101`."
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Grok is OpenAI-compatible, so we use the same `openai` client and `chat.completions` API as `function_calling_101`."
+   ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": "%pip install openai"
+   "execution_count": 1,
+   "id": "26c91866",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T05:57:34.514936Z",
+     "iopub.status.busy": "2026-06-09T05:57:34.514717Z",
+     "iopub.status.idle": "2026-06-09T05:57:34.940496Z",
+     "shell.execute_reply": "2026-06-09T05:57:34.939846Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: openai in ./nbvenv/lib/python3.14/site-packages (2.41.0)\r\n",
+      "Requirement already satisfied: anyio<5,>=3.5.0 in ./nbvenv/lib/python3.14/site-packages (from openai) (4.13.0)\r\n",
+      "Requirement already satisfied: distro<2,>=1.7.0 in ./nbvenv/lib/python3.14/site-packages (from openai) (1.9.0)\r\n",
+      "Requirement already satisfied: httpx<1,>=0.23.0 in ./nbvenv/lib/python3.14/site-packages (from openai) (0.28.1)\r\n",
+      "Requirement already satisfied: jiter<1,>=0.10.0 in ./nbvenv/lib/python3.14/site-packages (from openai) (0.15.0)\r\n",
+      "Requirement already satisfied: pydantic<3,>=1.9.0 in ./nbvenv/lib/python3.14/site-packages (from openai) (2.13.4)\r\n",
+      "Requirement already satisfied: sniffio in ./nbvenv/lib/python3.14/site-packages (from openai) (1.3.1)\r\n",
+      "Requirement already satisfied: tqdm>4 in ./nbvenv/lib/python3.14/site-packages (from openai) (4.68.1)\r\n",
+      "Requirement already satisfied: typing-extensions<5,>=4.11 in ./nbvenv/lib/python3.14/site-packages (from openai) (4.15.0)\r\n",
+      "Requirement already satisfied: idna>=2.8 in ./nbvenv/lib/python3.14/site-packages (from anyio<5,>=3.5.0->openai) (3.18)\r\n",
+      "Requirement already satisfied: certifi in ./nbvenv/lib/python3.14/site-packages (from httpx<1,>=0.23.0->openai) (2026.5.20)\r\n",
+      "Requirement already satisfied: httpcore==1.* in ./nbvenv/lib/python3.14/site-packages (from httpx<1,>=0.23.0->openai) (1.0.9)\r\n",
+      "Requirement already satisfied: h11>=0.16 in ./nbvenv/lib/python3.14/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->openai) (0.16.0)\r\n",
+      "Requirement already satisfied: annotated-types>=0.6.0 in ./nbvenv/lib/python3.14/site-packages (from pydantic<3,>=1.9.0->openai) (0.7.0)\r\n",
+      "Requirement already satisfied: pydantic-core==2.46.4 in ./nbvenv/lib/python3.14/site-packages (from pydantic<3,>=1.9.0->openai) (2.46.4)\r\n",
+      "Requirement already satisfied: typing-inspection>=0.4.2 in ./nbvenv/lib/python3.14/site-packages (from pydantic<3,>=1.9.0->openai) (0.4.2)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m26.1.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m26.1.2\u001b[0m\r\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49m/private/tmp/nbvenv/bin/python -m pip install --upgrade pip\u001b[0m\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install openai"
+   ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
+   "execution_count": 2,
+   "id": "8bbb9250",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T05:57:34.941892Z",
+     "iopub.status.busy": "2026-06-09T05:57:34.941785Z",
+     "iopub.status.idle": "2026-06-09T05:57:35.099591Z",
+     "shell.execute_reply": "2026-06-09T05:57:35.099044Z"
+    }
+   },
    "outputs": [],
-   "source": "import os, json\nfrom openai import OpenAI\n\n# Grok via the OpenAI-compatible endpoint (set XAI_API_KEY in your environment).\nclient = OpenAI(api_key=os.environ[\"XAI_API_KEY\"], base_url=\"https://api.x.ai/v1\")\nMODEL = \"grok-4\""
+   "source": [
+    "import os, json\n",
+    "from openai import OpenAI\n",
+    "\n",
+    "# Grok via the OpenAI-compatible endpoint (set XAI_API_KEY in your environment).\n",
+    "client = OpenAI(api_key=os.environ[\"XAI_API_KEY\"], base_url=\"https://api.x.ai/v1\")\n",
+    "MODEL = \"grok-4.3\""
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "4ed358f0",
    "metadata": {},
-   "source": "## 1. Tools — one read-only, one irreversible\n\n`get_invoice` just reads. `release_payment` moves money — that's the one we want a human to sign off on for large amounts."
+   "source": [
+    "## 1. Tools — one read-only, one irreversible\n",
+    "\n",
+    "`get_invoice` just reads. `release_payment` moves money — that's the one we want a human to sign off on for large amounts."
+   ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
+   "execution_count": 3,
+   "id": "0f7b5d6d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T05:57:35.100750Z",
+     "iopub.status.busy": "2026-06-09T05:57:35.100683Z",
+     "iopub.status.idle": "2026-06-09T05:57:35.103083Z",
+     "shell.execute_reply": "2026-06-09T05:57:35.102748Z"
+    }
+   },
    "outputs": [],
-   "source": "def get_invoice(invoice_id: str):\n    \"\"\"Read-only: look up an invoice.\"\"\"\n    return {\"invoice_id\": invoice_id, \"amount_due\": 82000, \"vendor\": \"acct_9f12\"}\n\ndef release_payment(amount: float, destination: str):\n    \"\"\"IRREVERSIBLE: release a wire/ACH payment.\"\"\"\n    # A real implementation would move money here.\n    return {\"status\": \"released\", \"amount\": amount, \"destination\": destination}\n\ntools_map = {\"get_invoice\": get_invoice, \"release_payment\": release_payment}\n\ntools_definition = [\n    {\"type\": \"function\", \"function\": {\n        \"name\": \"get_invoice\",\n        \"description\": \"Look up an invoice (read-only).\",\n        \"parameters\": {\"type\": \"object\",\n            \"properties\": {\"invoice_id\": {\"type\": \"string\"}},\n            \"required\": [\"invoice_id\"]}}},\n    {\"type\": \"function\", \"function\": {\n        \"name\": \"release_payment\",\n        \"description\": \"Release a wire/ACH payment. IRREVERSIBLE — money leaves the account.\",\n        \"parameters\": {\"type\": \"object\",\n            \"properties\": {\"amount\": {\"type\": \"number\"}, \"destination\": {\"type\": \"string\"}},\n            \"required\": [\"amount\", \"destination\"]}}},\n]"
+   "source": [
+    "def get_invoice(invoice_id: str):\n",
+    "    \"\"\"Read-only: look up an invoice.\"\"\"\n",
+    "    return {\"invoice_id\": invoice_id, \"amount_due\": 82000, \"vendor\": \"acct_9f12\"}\n",
+    "\n",
+    "def release_payment(amount: float, destination: str):\n",
+    "    \"\"\"IRREVERSIBLE: release a wire/ACH payment.\"\"\"\n",
+    "    # A real implementation would move money here.\n",
+    "    return {\"status\": \"released\", \"amount\": amount, \"destination\": destination}\n",
+    "\n",
+    "tools_map = {\"get_invoice\": get_invoice, \"release_payment\": release_payment}\n",
+    "\n",
+    "tools_definition = [\n",
+    "    {\"type\": \"function\", \"function\": {\n",
+    "        \"name\": \"get_invoice\",\n",
+    "        \"description\": \"Look up an invoice (read-only).\",\n",
+    "        \"parameters\": {\"type\": \"object\",\n",
+    "            \"properties\": {\"invoice_id\": {\"type\": \"string\"}},\n",
+    "            \"required\": [\"invoice_id\"]}}},\n",
+    "    {\"type\": \"function\", \"function\": {\n",
+    "        \"name\": \"release_payment\",\n",
+    "        \"description\": \"Release a wire/ACH payment. IRREVERSIBLE — money leaves the account.\",\n",
+    "        \"parameters\": {\"type\": \"object\",\n",
+    "            \"properties\": {\"amount\": {\"type\": \"number\"}, \"destination\": {\"type\": \"string\"}},\n",
+    "            \"required\": [\"amount\", \"destination\"]}}},\n",
+    "]"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "5830ea60",
    "metadata": {},
-   "source": "## 2. The guard — which calls need a human\n\nA small, transparent policy. Read-only calls run freely; an irreversible payment over a threshold (or to a blocked destination) returns a decision the loop will act on. Keeping the decision shape — `allow` / `signoff_required` / `deny` — lets you swap in a hosted policy engine later without changing the loop."
+   "source": [
+    "## 2. The guard — which calls need a human\n",
+    "\n",
+    "A small, transparent policy. Read-only calls run freely; an irreversible payment over a threshold (or to a blocked destination) returns a decision the loop will act on. Keeping the decision shape — `allow` / `signoff_required` / `deny` — lets you swap in a hosted policy engine later without changing the loop."
+   ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
+   "execution_count": 4,
+   "id": "fdc134df",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T05:57:35.104109Z",
+     "iopub.status.busy": "2026-06-09T05:57:35.104039Z",
+     "iopub.status.idle": "2026-06-09T05:57:35.105943Z",
+     "shell.execute_reply": "2026-06-09T05:57:35.105667Z"
+    }
+   },
    "outputs": [],
-   "source": "IRREVERSIBLE = {\"release_payment\"}\nSIGNOFF_THRESHOLD = 50_000\n\ndef guard(tool_name: str, args: dict) -> dict:\n    if tool_name not in IRREVERSIBLE:\n        return {\"decision\": \"allow\"}                       # read-only / low-risk\n    if \"sanctioned\" in str(args.get(\"destination\", \"\")):\n        return {\"decision\": \"deny\", \"reason\": \"destination on blocklist\"}\n    if float(args.get(\"amount\", 0)) >= SIGNOFF_THRESHOLD:\n        return {\"decision\": \"signoff_required\",\n                \"reason\": f\"payment >= ${SIGNOFF_THRESHOLD:,}\"}\n    return {\"decision\": \"allow\"}"
+   "source": [
+    "IRREVERSIBLE = {\"release_payment\"}\n",
+    "SIGNOFF_THRESHOLD = 50_000\n",
+    "\n",
+    "def guard(tool_name: str, args: dict) -> dict:\n",
+    "    if tool_name not in IRREVERSIBLE:\n",
+    "        return {\"decision\": \"allow\"}                       # read-only / low-risk\n",
+    "    if \"sanctioned\" in str(args.get(\"destination\", \"\")):\n",
+    "        return {\"decision\": \"deny\", \"reason\": \"destination on blocklist\"}\n",
+    "    if float(args.get(\"amount\", 0)) >= SIGNOFF_THRESHOLD:\n",
+    "        return {\"decision\": \"signoff_required\",\n",
+    "                \"reason\": f\"payment >= ${SIGNOFF_THRESHOLD:,}\"}\n",
+    "    return {\"decision\": \"allow\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "145386c8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T05:57:35.106692Z",
+     "iopub.status.busy": "2026-06-09T05:57:35.106644Z",
+     "iopub.status.idle": "2026-06-09T05:57:35.108419Z",
+     "shell.execute_reply": "2026-06-09T05:57:35.108052Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "get_invoice({'invoice_id': 'INV-1'}) -> allow\n",
+      "release_payment({'amount': 30, 'destination': 'acct_a'}) -> allow\n",
+      "release_payment({'amount': 82000, 'destination': 'acct_b'}) -> signoff_required\n",
+      "release_payment({'amount': 5000, 'destination': 'acct_sanctioned'}) -> deny\n"
+     ]
+    }
+   ],
+   "source": [
+    "# The policy in action (no model call needed):\n",
+    "for name, args in [\n",
+    "    (\"get_invoice\",     {\"invoice_id\": \"INV-1\"}),\n",
+    "    (\"release_payment\", {\"amount\": 30,    \"destination\": \"acct_a\"}),\n",
+    "    (\"release_payment\", {\"amount\": 82000, \"destination\": \"acct_b\"}),\n",
+    "    (\"release_payment\", {\"amount\": 5000,  \"destination\": \"acct_sanctioned\"}),\n",
+    "]:\n",
+    "    print(f\"{name}({args}) -> {guard(name, args)['decision']}\")"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "2dae7319",
    "metadata": {},
-   "source": "## 3. The approval step\n\nHere we prompt on the command line. In production a *named* human approves out-of-band (a dashboard or Slack) and the action resumes asynchronously, so high-volume flows never block waiting on a person."
+   "source": [
+    "## 3. The approval step\n",
+    "\n",
+    "This is the integration point for a *named* human's decision. In production they approve out-of-band (a dashboard or Slack) and the action resumes asynchronously, so high-volume flows never block on a person. For this runnable notebook we auto-approve."
+   ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
+   "execution_count": 6,
+   "id": "626cffa5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T05:57:35.109176Z",
+     "iopub.status.busy": "2026-06-09T05:57:35.109122Z",
+     "iopub.status.idle": "2026-06-09T05:57:35.110720Z",
+     "shell.execute_reply": "2026-06-09T05:57:35.110375Z"
+    }
+   },
    "outputs": [],
-   "source": "def request_human_signoff(tool_name: str, args: dict, reason: str) -> bool:\n    print(f\"\\n  ⚠️  Sign-off required: {tool_name}({args}) — {reason}\")\n    return input(\"  Approve? [y/N]: \").strip().lower() == \"y\""
+   "source": [
+    "def request_human_signoff(tool_name: str, args: dict, reason: str) -> bool:\n",
+    "    \"\"\"In production a NAMED human approves out-of-band (dashboard / Slack) and the\n",
+    "    action resumes asynchronously. For this runnable demo we auto-approve and print\n",
+    "    what the human would see.\"\"\"\n",
+    "    print(f\"  sign-off required: {tool_name}({args}) -- {reason}\")\n",
+    "    print(\"  (demo: auto-approving; wire this to your real approval UI in production)\")\n",
+    "    return True"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "f970ef02",
    "metadata": {},
-   "source": "## 4. The guarded tool-calling loop\n\nThis is `function_calling_101`'s handler with one addition: before running a tool call, we check `guard()` and route irreversible ones through approval."
+   "source": [
+    "## 4. The guarded tool-calling loop\n",
+    "\n",
+    "This is `function_calling_101`'s handler with one addition: before running a tool call, we check `guard()` and route irreversible ones through approval."
+   ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
+   "execution_count": 7,
+   "id": "d79cefb2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T05:57:35.111536Z",
+     "iopub.status.busy": "2026-06-09T05:57:35.111467Z",
+     "iopub.status.idle": "2026-06-09T05:57:35.113844Z",
+     "shell.execute_reply": "2026-06-09T05:57:35.113542Z"
+    }
+   },
    "outputs": [],
-   "source": "def run_guarded(prompt: str):\n    chat_history = [\n        {\"role\": \"system\", \"content\": \"You are an autonomous treasury assistant. Use the tools to carry out the request; do not ask the user to confirm.\"},\n        {\"role\": \"user\", \"content\": prompt},\n    ]\n    msg = client.chat.completions.create(\n        model=MODEL, messages=chat_history,\n        tools=tools_definition, tool_choice=\"auto\").choices[0].message\n    chat_history.append(msg.to_dict())\n\n    if not msg.tool_calls:\n        print(msg.content); return\n\n    for tool_call in msg.tool_calls:\n        name = tool_call.function.name\n        args = json.loads(tool_call.function.arguments)\n        decision = guard(name, args)\n\n        if decision[\"decision\"] == \"deny\":\n            result = {\"error\": f\"blocked: {decision['reason']}\"}\n        elif decision[\"decision\"] == \"signoff_required\":\n            approved = request_human_signoff(name, args, decision[\"reason\"])\n            result = tools_map[name](**args) if approved else {\"error\": \"human sign-off declined\"}\n        else:\n            result = tools_map[name](**args)\n\n        print(f\"  {name}({args}) -> {decision['decision']}\")\n        chat_history.append({\"role\": \"tool\", \"tool_call_id\": tool_call.id, \"content\": json.dumps(result)})\n\n    final = client.chat.completions.create(\n        model=MODEL, messages=chat_history,\n        tools=tools_definition, tool_choice=\"auto\").choices[0].message\n    print(\"\\n\" + (final.content or \"\"))"
+   "source": [
+    "def run_guarded(prompt: str, max_turns: int = 6):\n",
+    "    chat_history = [\n",
+    "        {\"role\": \"system\", \"content\": \"You are an autonomous treasury assistant. Use the tools to carry out the request; do not ask the user to confirm.\"},\n",
+    "        {\"role\": \"user\", \"content\": prompt},\n",
+    "    ]\n",
+    "    for _ in range(max_turns):\n",
+    "        msg = client.chat.completions.create(\n",
+    "            model=MODEL, messages=chat_history,\n",
+    "            tools=tools_definition, tool_choice=\"auto\").choices[0].message\n",
+    "        chat_history.append(msg.to_dict())\n",
+    "\n",
+    "        if not msg.tool_calls:\n",
+    "            print(\"\\n\" + (msg.content or \"\"))\n",
+    "            return\n",
+    "\n",
+    "        for tool_call in msg.tool_calls:\n",
+    "            name = tool_call.function.name\n",
+    "            args = json.loads(tool_call.function.arguments)\n",
+    "            decision = guard(name, args)\n",
+    "\n",
+    "            if decision[\"decision\"] == \"deny\":\n",
+    "                result = {\"error\": f\"blocked: {decision['reason']}\"}\n",
+    "            elif decision[\"decision\"] == \"signoff_required\":\n",
+    "                approved = request_human_signoff(name, args, decision[\"reason\"])\n",
+    "                result = tools_map[name](**args) if approved else {\"error\": \"human sign-off declined\"}\n",
+    "            else:\n",
+    "                result = tools_map[name](**args)\n",
+    "\n",
+    "            print(f\"  {name}({args}) -> {decision['decision']}\")\n",
+    "            chat_history.append({\"role\": \"tool\", \"tool_call_id\": tool_call.id, \"content\": json.dumps(result)})"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "babed1ef",
    "metadata": {},
-   "source": "## 5. Try it\n\nA small refund runs straight through. A large payment stops for a human."
+   "source": [
+    "## 5. Try it\n",
+    "\n",
+    "A small refund runs straight through. A large payment stops for a human."
+   ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": "# Small — runs immediately\nrun_guarded(\"Refund $30 to the customer on order 5510.\")"
+   "execution_count": 8,
+   "id": "70d54747",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T05:57:35.114764Z",
+     "iopub.status.busy": "2026-06-09T05:57:35.114702Z",
+     "iopub.status.idle": "2026-06-09T05:57:42.286994Z",
+     "shell.execute_reply": "2026-06-09T05:57:42.285929Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  get_invoice({'invoice_id': '5510'}) -> allow\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  release_payment({'amount': 30.0, 'destination': 'acct_9f12'}) -> allow\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Refund of $30 processed successfully to acct_9f12 for order 5510.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Small — runs immediately\n",
+    "run_guarded(\"Refund $30 to the customer on order 5510.\")"
+   ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": "# Large — requires sign-off (answer y/N at the prompt)\nrun_guarded(\"Pay invoice INV-4421 in full to the vendor.\")"
+   "execution_count": 9,
+   "id": "464baa38",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T05:57:42.289419Z",
+     "iopub.status.busy": "2026-06-09T05:57:42.289221Z",
+     "iopub.status.idle": "2026-06-09T05:57:45.455109Z",
+     "shell.execute_reply": "2026-06-09T05:57:45.454225Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  get_invoice({'invoice_id': 'INV-4421'}) -> allow\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  sign-off required: release_payment({'amount': 82000.0, 'destination': 'acct_9f12'}) -- payment >= $50,000\n",
+      "  (demo: auto-approving; wire this to your real approval UI in production)\n",
+      "  release_payment({'amount': 82000.0, 'destination': 'acct_9f12'}) -> signoff_required\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Payment released for INV-4421: $82,000.00 to acct_9f12.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Large — requires sign-off (answer y/N at the prompt)\n",
+    "run_guarded(\"Pay invoice INV-4421 in full to the vendor.\")"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "8a16d80b",
    "metadata": {},
-   "source": "## Taking this to production\n\nThe policy above is a few lines for clarity. A real deployment usually wants:\n\n- a **policy engine** you can audit and version, so *which rule applied* is provable after the fact;\n- **offline-verifiable receipts** of each decision — who approved what, checkable without calling home;\n- **async, out-of-band approval** so high-volume flows aren't blocked on a human.\n\n[EMILIA Protocol](https://github.com/emiliaprotocol/emilia-protocol) is one open-source (Apache-2.0) implementation of this pattern — a drop-in guard for OpenAI-compatible clients (Grok included) plus a reproducible cross-model benchmark. The local `guard()` above mirrors its `allow` / `signoff_required` / `deny` decision shape, so swapping in a hosted engine is a one-line change."
+   "source": [
+    "## Taking this to production\n",
+    "\n",
+    "The policy above is a few lines for clarity. A real deployment usually wants:\n",
+    "\n",
+    "- a **policy engine** you can audit and version, so *which rule applied* is provable after the fact;\n",
+    "- **offline-verifiable receipts** of each decision — who approved what, checkable without calling home;\n",
+    "- **async, out-of-band approval** so high-volume flows aren't blocked on a human.\n",
+    "\n",
+    "[EMILIA Protocol](https://github.com/emiliaprotocol/emilia-protocol) is one open-source (Apache-2.0) implementation of this pattern — a drop-in guard for OpenAI-compatible clients (Grok included) plus a reproducible cross-model benchmark. The local `guard()` above mirrors its `allow` / `signoff_required` / `deny` decision shape, so swapping in a hosted engine is a one-line change."
+   ]
   }
  ],
  "metadata": {
@@ -104,8 +437,16 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.11"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.5"
   }
  },
  "nbformat": 4,

--- a/examples/human_in_the_loop_signoff/guide.ipynb
+++ b/examples/human_in_the_loop_signoff/guide.ipynb
@@ -1,0 +1,113 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Human Sign-off for Irreversible Tool Calls\n\nGrok's function calling lets an agent *act* — look things up, call APIs, move data. For most calls that's exactly what you want. But some actions are **irreversible**: sending a payment, changing a payout account, deleting records, deploying code. For those you often want a **named human to approve before the action runs** — without slowing down everything else.\n\nThis cookbook adds a minimal human-in-the-loop step on top of [function calling](../function_calling_101/guide.ipynb):\n\n1. **Classify** each tool call — most are low-risk and run immediately.\n2. **Route** irreversible ones through an approval step (`allow` / `signoff_required` / `deny`).\n3. **Execute** only once a human has approved.\n\nWe use a tiny local policy so the whole notebook runs with just your xAI API key. The last section shows how to take it to production."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Setup\n\nGrok is OpenAI-compatible, so we use the same `openai` client and `chat.completions` API as `function_calling_101`."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "%pip install openai"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import os, json\nfrom openai import OpenAI\n\n# Grok via the OpenAI-compatible endpoint (set XAI_API_KEY in your environment).\nclient = OpenAI(api_key=os.environ[\"XAI_API_KEY\"], base_url=\"https://api.x.ai/v1\")\nMODEL = \"grok-4\""
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. Tools — one read-only, one irreversible\n\n`get_invoice` just reads. `release_payment` moves money — that's the one we want a human to sign off on for large amounts."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "def get_invoice(invoice_id: str):\n    \"\"\"Read-only: look up an invoice.\"\"\"\n    return {\"invoice_id\": invoice_id, \"amount_due\": 82000, \"vendor\": \"acct_9f12\"}\n\ndef release_payment(amount: float, destination: str):\n    \"\"\"IRREVERSIBLE: release a wire/ACH payment.\"\"\"\n    # A real implementation would move money here.\n    return {\"status\": \"released\", \"amount\": amount, \"destination\": destination}\n\ntools_map = {\"get_invoice\": get_invoice, \"release_payment\": release_payment}\n\ntools_definition = [\n    {\"type\": \"function\", \"function\": {\n        \"name\": \"get_invoice\",\n        \"description\": \"Look up an invoice (read-only).\",\n        \"parameters\": {\"type\": \"object\",\n            \"properties\": {\"invoice_id\": {\"type\": \"string\"}},\n            \"required\": [\"invoice_id\"]}}},\n    {\"type\": \"function\", \"function\": {\n        \"name\": \"release_payment\",\n        \"description\": \"Release a wire/ACH payment. IRREVERSIBLE — money leaves the account.\",\n        \"parameters\": {\"type\": \"object\",\n            \"properties\": {\"amount\": {\"type\": \"number\"}, \"destination\": {\"type\": \"string\"}},\n            \"required\": [\"amount\", \"destination\"]}}},\n]"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. The guard — which calls need a human\n\nA small, transparent policy. Read-only calls run freely; an irreversible payment over a threshold (or to a blocked destination) returns a decision the loop will act on. Keeping the decision shape — `allow` / `signoff_required` / `deny` — lets you swap in a hosted policy engine later without changing the loop."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "IRREVERSIBLE = {\"release_payment\"}\nSIGNOFF_THRESHOLD = 50_000\n\ndef guard(tool_name: str, args: dict) -> dict:\n    if tool_name not in IRREVERSIBLE:\n        return {\"decision\": \"allow\"}                       # read-only / low-risk\n    if \"sanctioned\" in str(args.get(\"destination\", \"\")):\n        return {\"decision\": \"deny\", \"reason\": \"destination on blocklist\"}\n    if float(args.get(\"amount\", 0)) >= SIGNOFF_THRESHOLD:\n        return {\"decision\": \"signoff_required\",\n                \"reason\": f\"payment >= ${SIGNOFF_THRESHOLD:,}\"}\n    return {\"decision\": \"allow\"}"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. The approval step\n\nHere we prompt on the command line. In production a *named* human approves out-of-band (a dashboard or Slack) and the action resumes asynchronously, so high-volume flows never block waiting on a person."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "def request_human_signoff(tool_name: str, args: dict, reason: str) -> bool:\n    print(f\"\\n  ⚠️  Sign-off required: {tool_name}({args}) — {reason}\")\n    return input(\"  Approve? [y/N]: \").strip().lower() == \"y\""
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. The guarded tool-calling loop\n\nThis is `function_calling_101`'s handler with one addition: before running a tool call, we check `guard()` and route irreversible ones through approval."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "def run_guarded(prompt: str):\n    chat_history = [\n        {\"role\": \"system\", \"content\": \"You are an autonomous treasury assistant. Use the tools to carry out the request; do not ask the user to confirm.\"},\n        {\"role\": \"user\", \"content\": prompt},\n    ]\n    msg = client.chat.completions.create(\n        model=MODEL, messages=chat_history,\n        tools=tools_definition, tool_choice=\"auto\").choices[0].message\n    chat_history.append(msg.to_dict())\n\n    if not msg.tool_calls:\n        print(msg.content); return\n\n    for tool_call in msg.tool_calls:\n        name = tool_call.function.name\n        args = json.loads(tool_call.function.arguments)\n        decision = guard(name, args)\n\n        if decision[\"decision\"] == \"deny\":\n            result = {\"error\": f\"blocked: {decision['reason']}\"}\n        elif decision[\"decision\"] == \"signoff_required\":\n            approved = request_human_signoff(name, args, decision[\"reason\"])\n            result = tools_map[name](**args) if approved else {\"error\": \"human sign-off declined\"}\n        else:\n            result = tools_map[name](**args)\n\n        print(f\"  {name}({args}) -> {decision['decision']}\")\n        chat_history.append({\"role\": \"tool\", \"tool_call_id\": tool_call.id, \"content\": json.dumps(result)})\n\n    final = client.chat.completions.create(\n        model=MODEL, messages=chat_history,\n        tools=tools_definition, tool_choice=\"auto\").choices[0].message\n    print(\"\\n\" + (final.content or \"\"))"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. Try it\n\nA small refund runs straight through. A large payment stops for a human."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "# Small — runs immediately\nrun_guarded(\"Refund $30 to the customer on order 5510.\")"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "# Large — requires sign-off (answer y/N at the prompt)\nrun_guarded(\"Pay invoice INV-4421 in full to the vendor.\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Taking this to production\n\nThe policy above is a few lines for clarity. A real deployment usually wants:\n\n- a **policy engine** you can audit and version, so *which rule applied* is provable after the fact;\n- **offline-verifiable receipts** of each decision — who approved what, checkable without calling home;\n- **async, out-of-band approval** so high-volume flows aren't blocked on a human.\n\n[EMILIA Protocol](https://github.com/emiliaprotocol/emilia-protocol) is one open-source (Apache-2.0) implementation of this pattern — a drop-in guard for OpenAI-compatible clients (Grok included) plus a reproducible cross-model benchmark. The local `guard()` above mirrors its `allow` / `signoff_required` / `deny` decision shape, so swapping in a hosted engine is a one-line change."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/human_in_the_loop_signoff/guide.ipynb
+++ b/examples/human_in_the_loop_signoff/guide.ipynb
@@ -97,14 +97,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "import os, json\n",
-    "from openai import OpenAI\n",
-    "\n",
-    "# Grok via the OpenAI-compatible endpoint (set XAI_API_KEY in your environment).\n",
-    "client = OpenAI(api_key=os.environ[\"XAI_API_KEY\"], base_url=\"https://api.x.ai/v1\")\n",
-    "MODEL = \"grok-4.3\""
-   ]
+   "source": "import os, json\nfrom openai import OpenAI\n\n# Grok via the OpenAI-compatible endpoint (set XAI_API_KEY in your environment).\nclient = OpenAI(api_key=os.environ[\"XAI_API_KEY\"], base_url=\"https://api.x.ai/v1\")\nMODEL = \"grok-4.3\"  # any chat model your xAI key can access"
   },
   {
    "cell_type": "markdown",
@@ -408,10 +401,7 @@
      ]
     }
    ],
-   "source": [
-    "# Large — requires sign-off (answer y/N at the prompt)\n",
-    "run_guarded(\"Pay invoice INV-4421 in full to the vendor.\")"
-   ]
+   "source": "# Large — triggers sign-off before the payment runs\nrun_guarded(\"Pay invoice INV-4421 in full to the vendor.\")"
   },
   {
    "cell_type": "markdown",

--- a/examples/human_in_the_loop_signoff/guide.ipynb
+++ b/examples/human_in_the_loop_signoff/guide.ipynb
@@ -7,11 +7,11 @@
    "source": [
     "# Human Sign-off for Irreversible Tool Calls\n",
     "\n",
-    "Grok's function calling lets an agent *act* — look things up, call APIs, move data. For most calls that's exactly what you want. But some actions are **irreversible**: sending a payment, changing a payout account, deleting records, deploying code. For those you often want a **named human to approve before the action runs** — without slowing down everything else.\n",
+    "Grok's function calling lets an agent *act* \u2014 look things up, call APIs, move data. For most calls that's exactly what you want. But some actions are **irreversible**: sending a payment, changing a payout account, deleting records, deploying code. For those you often want a **named human to approve before the action runs** \u2014 without slowing down everything else.\n",
     "\n",
     "This cookbook adds a minimal human-in-the-loop step on top of [function calling](../function_calling_101/guide.ipynb):\n",
     "\n",
-    "1. **Classify** each tool call — most are low-risk and run immediately.\n",
+    "1. **Classify** each tool call \u2014 most are low-risk and run immediately.\n",
     "2. **Route** irreversible ones through an approval step (`allow` / `signoff_required` / `deny`).\n",
     "3. **Execute** only once a human has approved.\n",
     "\n",
@@ -104,9 +104,9 @@
    "id": "4ed358f0",
    "metadata": {},
    "source": [
-    "## 1. Tools — one read-only, one irreversible\n",
+    "## 1. Tools \u2014 one read-only, one irreversible\n",
     "\n",
-    "`get_invoice` just reads. `release_payment` moves money — that's the one we want a human to sign off on for large amounts."
+    "`get_invoice` just reads. `release_payment` moves money \u2014 that's the one we want a human to sign off on for large amounts."
    ]
   },
   {
@@ -143,7 +143,7 @@
     "            \"required\": [\"invoice_id\"]}}},\n",
     "    {\"type\": \"function\", \"function\": {\n",
     "        \"name\": \"release_payment\",\n",
-    "        \"description\": \"Release a wire/ACH payment. IRREVERSIBLE — money leaves the account.\",\n",
+    "        \"description\": \"Release a wire/ACH payment. IRREVERSIBLE \u2014 money leaves the account.\",\n",
     "        \"parameters\": {\"type\": \"object\",\n",
     "            \"properties\": {\"amount\": {\"type\": \"number\"}, \"destination\": {\"type\": \"string\"}},\n",
     "            \"required\": [\"amount\", \"destination\"]}}},\n",
@@ -155,9 +155,9 @@
    "id": "5830ea60",
    "metadata": {},
    "source": [
-    "## 2. The guard — which calls need a human\n",
+    "## 2. The guard \u2014 which calls need a human\n",
     "\n",
-    "A small, transparent policy. Read-only calls run freely; an irreversible payment over a threshold (or to a blocked destination) returns a decision the loop will act on. Keeping the decision shape — `allow` / `signoff_required` / `deny` — lets you swap in a hosted policy engine later without changing the loop."
+    "A small, transparent policy. Read-only calls run freely; an irreversible payment over a threshold (or to a blocked destination) returns a decision the loop will act on. Keeping the decision shape \u2014 `allow` / `signoff_required` / `deny` \u2014 lets you swap in a hosted policy engine later without changing the loop."
    ]
   },
   {
@@ -359,7 +359,7 @@
     }
    ],
    "source": [
-    "# Small — runs immediately\n",
+    "# Small \u2014 runs immediately\n",
     "run_guarded(\"Refund $30 to the customer on order 5510.\")"
    ]
   },
@@ -401,7 +401,7 @@
      ]
     }
    ],
-   "source": "# Large — triggers sign-off before the payment runs\nrun_guarded(\"Pay invoice INV-4421 in full to the vendor.\")"
+   "source": "# Large \u2014 triggers sign-off before the payment runs\nrun_guarded(\"Pay invoice INV-4421 in full to the vendor.\")"
   },
   {
    "cell_type": "markdown",
@@ -413,10 +413,28 @@
     "The policy above is a few lines for clarity. A real deployment usually wants:\n",
     "\n",
     "- a **policy engine** you can audit and version, so *which rule applied* is provable after the fact;\n",
-    "- **offline-verifiable receipts** of each decision — who approved what, checkable without calling home;\n",
-    "- **async, out-of-band approval** so high-volume flows aren't blocked on a human.\n",
+    "- **offline-verifiable receipts** of each decision \u2014 who approved what, checkable without calling home;\n",
+    "- **async, out-of-band approval** so high-volume flows aren't blocked on a human;\n",
+    "- **approver-held signing keys** \u2014 the human approves on their own device (Touch ID / passkey / security key), so the operator orchestrates the approval but cannot forge it, and the receipt verifies offline.\n",
     "\n",
-    "[EMILIA Protocol](https://github.com/emiliaprotocol/emilia-protocol) is one open-source (Apache-2.0) implementation of this pattern — a drop-in guard for OpenAI-compatible clients (Grok included) plus a reproducible cross-model benchmark. The local `guard()` above mirrors its `allow` / `signoff_required` / `deny` decision shape, so swapping in a hosted engine is a one-line change."
+    "In that strongest form the toy `request_human_signoff()` above becomes four real steps against a signoff service. The agent never sees the passkey challenge \u2014 WebAuthn happens on the human's device, out of band \u2014 so the agent's job is to request the signoff and wait:\n",
+    "\n",
+    "```python\n",
+    "# 1. mint a pre-action receipt; the policy engine decides\n",
+    "receipt = guard.mint(action_type=\"release_payment\", amount=82_000, ...)\n",
+    "if receipt[\"signoff_required\"]:\n",
+    "    # 2. open a signoff; route the URL to a named human (Slack / SMS / email)\n",
+    "    signoff = guard.request_signoff(receipt[\"receipt_id\"])\n",
+    "    notify_human(signoff[\"approval_url\"])        # they open it, review, Touch ID\n",
+    "    # 3. the agent waits \u2014 the signature is produced on the human's device\n",
+    "    result = guard.wait_for_signoff(receipt[\"receipt_id\"])\n",
+    "    if not result[\"approved\"]:\n",
+    "        return \"blocked \u2014 no human approval\"\n",
+    "# 4. only now does the irreversible tool run\n",
+    "release_payment(...)\n",
+    "```\n",
+    "\n",
+    "[EMILIA Protocol](https://github.com/emiliaprotocol/emilia-protocol) is one open-source (Apache-2.0) implementation of this pattern. The local `guard()` above mirrors its `allow` / `signoff_required` / `deny` decision shape, so swapping in the hosted engine is a small change. A runnable Grok integration of exactly those four steps \u2014 plus the offline receipt verifier \u2014 is in [`examples/grok_guard.py`](https://github.com/emiliaprotocol/emilia-protocol/blob/main/examples/grok_guard.py)."
    ]
   }
  ],

--- a/registry.yaml
+++ b/registry.yaml
@@ -82,3 +82,15 @@
     - Zhaohan Dong
   tags:
     - function-calling
+
+- title: "Human Sign-off for Irreversible Tool Calls"
+  path: examples/human_in_the_loop_signoff/guide.ipynb
+  description: "Add a human-in-the-loop approval step to a Grok function-calling agent: low-risk tool calls run immediately, irreversible ones (payments, account changes) require a named human's sign-off before they execute."
+  date: 2026-06-08
+  authors:
+    - Iman Schrock
+  tags:
+    - function-calling
+    - agents
+    - tool-use
+    - human-in-the-loop


### PR DESCRIPTION
## Description
Summary:
- Adds a cookbook that puts a human-in-the-loop approval step on top of `function_calling_101`. Low-risk tool calls run immediately; irreversible ones (payments, account changes) require a named human's sign-off before they execute.

Why this change matters:
- Agents increasingly call tools that take irreversible actions. This shows a minimal, practical pattern for gating just those calls — same `openai` client + `chat.completions` API as the existing function-calling cookbook, runnable with only an xAI API key (uses `grok-4.3`).

## Type(s) of Change
- [x] New Content

## Checklist
- [x] Read "How to Contribute" in `CONTRIBUTING.md`
- [x] Code follows style guidelines in "How to Contribute"
- [x] Included relevant dependencies
- [x] API key is not in committed files
- [x] Notebook runs end-to-end with cell outputs shown and no errors
- [x] Added new notebook entry to `registry.yaml`