### PR TITLE
[Content] Deterministic Guardrails for Grok Tool Calls

### DIFF
--- a/examples/deterministic_tool_call_guardrails/guide.ipynb
+++ b/examples/deterministic_tool_call_guardrails/guide.ipynb
@@ -1,0 +1,615 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "55354902",
+   "metadata": {},
+   "source": [
+    "# Deterministic Guardrails for Grok Tool Calls\n",
+    "\n",
+    "Function calling lets Grok decide *when* and *how* to invoke your tools. That power comes with three\n",
+    "failure modes that show up in production:\n",
+    "\n",
+    "1. **Bad arguments** — the model asks to call a tool with a value your function can't accept\n",
+    "   (a missing field, an out-of-enum string, a number out of range).\n",
+    "2. **Unsafe actions** — the model decides to fire an *irreversible* tool (send an email, place an\n",
+    "   order, delete a record) when it should have paused for a human.\n",
+    "3. **Malformed tool output** — a downstream API returns something that doesn't match the shape your\n",
+    "   prompt promised, and the garbage gets fed straight back into the model.\n",
+    "\n",
+    "None of these need another LLM call to catch. They are **deterministic, zero-token checks** you run in\n",
+    "plain Python *around* the model — fast, free, reproducible, and **fail-closed** (when in doubt, don't\n",
+    "execute). This cookbook builds four such guards and wires them into a complete Grok tool-calling loop.\n",
+    "\n",
+    "> **Related:** issue [#18](https://github.com/xai-org/xai-cookbook/issues/18) asks for *deterministic\n",
+    "> function-call contracts* for Grok examples. This recipe answers that need with nothing but\n",
+    "> [Pydantic](https://docs.pydantic.dev/) and the OpenAI SDK already used throughout this cookbook — no\n",
+    "> extra framework required. Thanks to [@rokoss21](https://github.com/rokoss21) for raising the topic.\n",
+    "\n",
+    "**What you'll build**\n",
+    "\n",
+    "| Guard | Runs | Catches |\n",
+    "|-------|------|---------|\n",
+    "| 1. Argument validation | *before* executing a tool | hallucinated / malformed arguments |\n",
+    "| 2. Action-tier gate | *before* executing a tool | irreversible actions auto-fired without approval |\n",
+    "| 3. Output verification | *after* executing a tool | tools returning off-contract data |\n",
+    "| 4. Grounding check | *before* trusting the final answer | numbers the model didn't actually get from a tool |\n",
+    "\n",
+    "This example is **complementary to** [Function Calling 101](../function_calling_101/guide.ipynb): that\n",
+    "notebook teaches the loop; this one teaches the safety layer around it.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5c06794",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "We use the same OpenAI-compatible client the rest of the cookbook uses, pointed at the xAI endpoint. The guards themselves are pure Python and run with or without an API key — so this notebook executes end-to-end even before you plug in a key."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "225ed31c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-23T16:39:52.946513Z",
+     "iopub.status.busy": "2026-07-23T16:39:52.946093Z",
+     "iopub.status.idle": "2026-07-23T16:39:53.675087Z",
+     "shell.execute_reply": "2026-07-23T16:39:53.674055Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%pip install openai pydantic python-dotenv --quiet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f3a6fd8f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-23T16:39:53.677780Z",
+     "iopub.status.busy": "2026-07-23T16:39:53.677530Z",
+     "iopub.status.idle": "2026-07-23T16:39:54.857590Z",
+     "shell.execute_reply": "2026-07-23T16:39:54.856456Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mode: OFFLINE DEMO (guards run against scripted responses)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "from openai import OpenAI\n",
+    "\n",
+    "load_dotenv()  # picks up XAI_API_KEY from a .env file if present\n",
+    "\n",
+    "XAI_API_KEY = os.environ.get(\"XAI_API_KEY\", \"\")\n",
+    "MODEL = \"grok-4\"\n",
+    "\n",
+    "# When a key is present we talk to the real Grok API. When it isn't, the notebook still runs\n",
+    "# end-to-end in an OFFLINE DEMO mode that returns scripted, representative model responses so the\n",
+    "# deterministic guards below execute against realistic inputs.\n",
+    "LIVE = bool(XAI_API_KEY)\n",
+    "client = OpenAI(base_url=\"https://api.x.ai/v1\", api_key=XAI_API_KEY) if LIVE else None\n",
+    "print(\"Mode:\", \"LIVE (real Grok API)\" if LIVE else \"OFFLINE DEMO (guards run against scripted responses)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23f92d17",
+   "metadata": {},
+   "source": [
+    "## Declare tools *and their contracts*\n",
+    "\n",
+    "The core idea: every tool carries a **contract** — a strict schema for its arguments *and* a schema for\n",
+    "its result. We use Pydantic models for both. `model_config = {\"extra\": \"forbid\"}` makes validation\n",
+    "**fail-closed**: any unexpected field is rejected rather than silently ignored.\n",
+    "\n",
+    "We define two tools with deliberately different risk profiles:\n",
+    "\n",
+    "* `get_weather` — read-only, safe to auto-execute.\n",
+    "* `send_frost_alert` — **irreversible** (it notifies people); it must never fire without approval.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "dd0671e8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-23T16:39:54.859814Z",
+     "iopub.status.busy": "2026-07-23T16:39:54.859590Z",
+     "iopub.status.idle": "2026-07-23T16:39:54.879631Z",
+     "shell.execute_reply": "2026-07-23T16:39:54.878783Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Registered tools: ['get_weather', 'send_frost_alert']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from enum import Enum\n",
+    "from typing import Callable, Literal\n",
+    "from pydantic import BaseModel, Field, ValidationError\n",
+    "\n",
+    "\n",
+    "class City(str, Enum):\n",
+    "    denver = \"denver\"\n",
+    "    boulder = \"boulder\"\n",
+    "    aspen = \"aspen\"\n",
+    "\n",
+    "\n",
+    "# ---- get_weather: read-only tool ----\n",
+    "class WeatherArgs(BaseModel):\n",
+    "    model_config = {\"extra\": \"forbid\"}  # fail-closed: reject unknown fields\n",
+    "    city: City = Field(description=\"City to look up, lower snake_case\")\n",
+    "    units: Literal[\"C\", \"F\"] = Field(default=\"C\", description=\"Temperature unit\")\n",
+    "\n",
+    "\n",
+    "class WeatherResult(BaseModel):\n",
+    "    model_config = {\"extra\": \"forbid\"}\n",
+    "    city: City\n",
+    "    temperature: int = Field(ge=-90, le=60, description=\"Temperature in the requested unit\")\n",
+    "    units: Literal[\"C\", \"F\"]\n",
+    "    condition: str\n",
+    "\n",
+    "\n",
+    "def get_weather(city: str, units: str = \"C\") -> dict:\n",
+    "    # A stand-in for a real weather API. Returns data that matches WeatherResult.\n",
+    "    table = {\"denver\": (-4, \"clear\"), \"boulder\": (-2, \"snow\"), \"aspen\": (-8, \"snow\")}\n",
+    "    temp_c, cond = table[city]\n",
+    "    temp = temp_c if units == \"C\" else round(temp_c * 9 / 5 + 32)\n",
+    "    return {\"city\": city, \"temperature\": temp, \"units\": units, \"condition\": cond}\n",
+    "\n",
+    "\n",
+    "# ---- send_frost_alert: IRREVERSIBLE tool ----\n",
+    "class FrostAlertArgs(BaseModel):\n",
+    "    model_config = {\"extra\": \"forbid\"}\n",
+    "    city: City\n",
+    "    message: str = Field(min_length=1, max_length=280)\n",
+    "\n",
+    "\n",
+    "def send_frost_alert(city: str, message: str) -> dict:\n",
+    "    # Imagine this pages every farmer in the region. We never want it fired by accident.\n",
+    "    return {\"delivered_to\": f\"{city}-subscribers\", \"message\": message}\n",
+    "\n",
+    "\n",
+    "# A tool = (callable, args schema, result schema, tier). Tier \"safe\" auto-runs; \"irreversible\" gates.\n",
+    "class Tool(BaseModel):\n",
+    "    model_config = {\"arbitrary_types_allowed\": True}\n",
+    "    fn: Callable\n",
+    "    args_model: type[BaseModel]\n",
+    "    result_model: type[BaseModel] | None\n",
+    "    tier: Literal[\"safe\", \"irreversible\"]\n",
+    "\n",
+    "\n",
+    "REGISTRY: dict[str, Tool] = {\n",
+    "    \"get_weather\": Tool(fn=get_weather, args_model=WeatherArgs, result_model=WeatherResult, tier=\"safe\"),\n",
+    "    \"send_frost_alert\": Tool(fn=send_frost_alert, args_model=FrostAlertArgs, result_model=None, tier=\"irreversible\"),\n",
+    "}\n",
+    "\n",
+    "# The tools payload sent to Grok is generated straight from the Pydantic schemas.\n",
+    "tools_payload = [\n",
+    "    {\"type\": \"function\", \"function\": {\n",
+    "        \"name\": name,\n",
+    "        \"description\": t.fn.__doc__ or name,\n",
+    "        \"parameters\": t.args_model.model_json_schema(),\n",
+    "    }} for name, t in REGISTRY.items()\n",
+    "]\n",
+    "print(\"Registered tools:\", list(REGISTRY))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc01a3c0",
+   "metadata": {},
+   "source": [
+    "## Guard 1 — Argument validation (fail-closed)\n",
+    "\n",
+    "Before we execute *anything*, we validate the model's requested arguments against the tool's\n",
+    "`args_model`. If validation fails we **do not call the function**. Instead we hand the structured error\n",
+    "back to the model as the tool result, which lets Grok correct itself on the next turn — a controlled\n",
+    "recovery instead of a crash or, worse, a call with garbage input."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ab73a8de",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-23T16:39:54.881677Z",
+     "iopub.status.busy": "2026-07-23T16:39:54.881467Z",
+     "iopub.status.idle": "2026-07-23T16:39:54.889702Z",
+     "shell.execute_reply": "2026-07-23T16:39:54.888149Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OK  -> city=<City.denver: 'denver'> units='C'\n",
+      "BLOCKED -> {'city': 'tokyo'} \n",
+      "            [{'type': 'enum', 'loc': ('city',), 'msg': \"Input should be 'denver', 'boulder' or 'aspen'\", 'ctx': {'expected': \"'denver', 'bould ...\n",
+      "BLOCKED -> {'city': 'denver', 'units': 'kelvin'} \n",
+      "            [{'type': 'literal_error', 'loc': ('units',), 'msg': \"Input should be 'C' or 'F'\", 'ctx': {'expected': \"'C' or 'F'\"}}] ...\n",
+      "BLOCKED -> {'city': 'denver', 'drop_table': True} \n",
+      "            [{'type': 'extra_forbidden', 'loc': ('drop_table',), 'msg': 'Extra inputs are not permitted'}] ...\n"
+     ]
+    }
+   ],
+   "source": [
+    "from dataclasses import dataclass\n",
+    "\n",
+    "\n",
+    "@dataclass\n",
+    "class GuardError(Exception):\n",
+    "    guard: str\n",
+    "    detail: str\n",
+    "\n",
+    "\n",
+    "def validate_args(tool_name: str, raw_args: dict) -> BaseModel:\n",
+    "    \"\"\"Return a validated args model, or raise GuardError. Fail-closed.\"\"\"\n",
+    "    tool = REGISTRY.get(tool_name)\n",
+    "    if tool is None:\n",
+    "        raise GuardError(\"arg-validation\", f\"unknown tool '{tool_name}'\")\n",
+    "    try:\n",
+    "        return tool.args_model.model_validate(raw_args)\n",
+    "    except ValidationError as e:\n",
+    "        raise GuardError(\"arg-validation\", e.errors(include_url=False, include_input=False).__str__())\n",
+    "\n",
+    "\n",
+    "# Demo: a good call and three bad ones.\n",
+    "print(\"OK  ->\", validate_args(\"get_weather\", {\"city\": \"denver\", \"units\": \"C\"}))\n",
+    "for bad in [\n",
+    "    {\"city\": \"tokyo\"},                        # not in the City enum\n",
+    "    {\"city\": \"denver\", \"units\": \"kelvin\"},    # not an allowed unit\n",
+    "    {\"city\": \"denver\", \"drop_table\": True},   # unexpected field -> forbidden\n",
+    "]:\n",
+    "    try:\n",
+    "        validate_args(\"get_weather\", bad)\n",
+    "    except GuardError as g:\n",
+    "        print(\"BLOCKED ->\", bad, \"\\n           \", g.detail[:130], \"...\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4222e077",
+   "metadata": {},
+   "source": [
+    "## Guard 2 — Action-tier gate\n",
+    "\n",
+    "Reading the weather is harmless; paging every farmer in the county is not. We tag each tool with a\n",
+    "**tier** and refuse to auto-execute anything `irreversible`. In a real app the gate is where you route\n",
+    "to a human approval, a confirmation UI, or an allow-list. Here it simply blocks — **fail-closed** — so\n",
+    "an over-eager tool call can never take an irreversible action on its own."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "21c4c698",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-23T16:39:54.892928Z",
+     "iopub.status.busy": "2026-07-23T16:39:54.892566Z",
+     "iopub.status.idle": "2026-07-23T16:39:54.900114Z",
+     "shell.execute_reply": "2026-07-23T16:39:54.898464Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ALLOWED -> get_weather\n",
+      "GATED   -> send_frost_alert | 'send_frost_alert' is irreversible and requires explicit approval\n",
+      "ALLOWED -> send_frost_alert (after explicit approval)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def tier_gate(tool_name: str, auto_approved: set[str]) -> None:\n",
+    "    \"\"\"Raise GuardError if the tool is irreversible and not explicitly approved.\"\"\"\n",
+    "    tool = REGISTRY[tool_name]\n",
+    "    if tool.tier == \"irreversible\" and tool_name not in auto_approved:\n",
+    "        raise GuardError(\"tier-gate\", f\"'{tool_name}' is irreversible and requires explicit approval\")\n",
+    "\n",
+    "\n",
+    "# get_weather passes freely; send_frost_alert is blocked until a human approves it.\n",
+    "for name in [\"get_weather\", \"send_frost_alert\"]:\n",
+    "    try:\n",
+    "        tier_gate(name, auto_approved=set())\n",
+    "        print(\"ALLOWED ->\", name)\n",
+    "    except GuardError as g:\n",
+    "        print(\"GATED   ->\", name, \"|\", g.detail)\n",
+    "\n",
+    "# Once a human approves, the same call goes through:\n",
+    "tier_gate(\"send_frost_alert\", auto_approved={\"send_frost_alert\"})\n",
+    "print(\"ALLOWED -> send_frost_alert (after explicit approval)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38a84618",
+   "metadata": {},
+   "source": [
+    "## Guard 3 — Output verification\n",
+    "\n",
+    "A tool can be called with perfect arguments and still return junk — an upstream API changes, a null\n",
+    "sneaks in, a number arrives as a string. Before the result goes back to the model we validate it against\n",
+    "the tool's `result_model`. If it doesn't conform, we fail-closed rather than feeding off-contract data\n",
+    "into Grok's context."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "2b36be29",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-23T16:39:54.902214Z",
+     "iopub.status.busy": "2026-07-23T16:39:54.902001Z",
+     "iopub.status.idle": "2026-07-23T16:39:54.908844Z",
+     "shell.execute_reply": "2026-07-23T16:39:54.907881Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "VERIFIED -> {'city': <City.boulder: 'boulder'>, 'temperature': -2, 'units': 'C', 'condition': 'snow'}\n",
+      "BLOCKED  -> output-verification | get_weather returned off-contract data: Input should be less than or equal to 60\n"
+     ]
+    }
+   ],
+   "source": [
+    "def run_and_verify(tool_name: str, args: BaseModel) -> dict:\n",
+    "    \"\"\"Execute the tool and validate its output against the declared result schema.\"\"\"\n",
+    "    tool = REGISTRY[tool_name]\n",
+    "    result = tool.fn(**args.model_dump())\n",
+    "    if tool.result_model is not None:\n",
+    "        try:\n",
+    "            tool.result_model.model_validate(result)\n",
+    "        except ValidationError as e:\n",
+    "            raise GuardError(\"output-verification\",\n",
+    "                             f\"{tool_name} returned off-contract data: {e.errors(include_url=False)[0]['msg']}\")\n",
+    "    return result\n",
+    "\n",
+    "\n",
+    "# Happy path:\n",
+    "good = run_and_verify(\"get_weather\", WeatherArgs(city=City.boulder, units=\"C\"))\n",
+    "print(\"VERIFIED ->\", good)\n",
+    "\n",
+    "# Simulate a buggy tool that returns an impossible temperature (violates ge/le on WeatherResult):\n",
+    "REGISTRY[\"get_weather\"].fn = lambda city, units=\"C\": {\"city\": city, \"temperature\": 999, \"units\": units, \"condition\": \"?\"}\n",
+    "try:\n",
+    "    run_and_verify(\"get_weather\", WeatherArgs(city=City.boulder))\n",
+    "except GuardError as g:\n",
+    "    print(\"BLOCKED  ->\", g.guard, \"|\", g.detail)\n",
+    "REGISTRY[\"get_weather\"].fn = get_weather  # restore the real tool"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4eb51ce6",
+   "metadata": {},
+   "source": [
+    "## Guard 4 — Grounding check\n",
+    "\n",
+    "The final risk is subtle: the model produces a fluent answer that quotes a number it never actually got\n",
+    "from a tool. We keep a ledger of every value a verified tool returned, then require that any number in\n",
+    "the model's final answer appears in that ledger. If it cites `-2°C`, a tool must have returned `-2`.\n",
+    "This is a lightweight, deterministic anti-hallucination check — not a proof, but it catches invented\n",
+    "figures cheaply."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "442b35e8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-23T16:39:54.910970Z",
+     "iopub.status.busy": "2026-07-23T16:39:54.910718Z",
+     "iopub.status.idle": "2026-07-23T16:39:54.916253Z",
+     "shell.execute_reply": "2026-07-23T16:39:54.915263Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ledger: [{'city': 'boulder', 'temperature': -2, 'units': 'C', 'condition': 'snow'}]\n",
+      "GROUNDED -> answer matches tool output\n",
+      "BLOCKED  -> grounding | answer cites -20, which no tool returned\n"
+     ]
+    }
+   ],
+   "source": [
+    "import re\n",
+    "\n",
+    "\n",
+    "def grounding_check(answer: str, ledger: list[dict]) -> None:\n",
+    "    \"\"\"Every integer in `answer` must appear among the values a tool actually returned.\"\"\"\n",
+    "    grounded = set()\n",
+    "    for entry in ledger:\n",
+    "        for v in entry.values():\n",
+    "            if isinstance(v, (int, float)):\n",
+    "                grounded.add(int(v))\n",
+    "    for num in map(int, re.findall(r\"-?\\d+\", answer)):\n",
+    "        if num not in grounded:\n",
+    "            raise GuardError(\"grounding\", f\"answer cites {num}, which no tool returned\")\n",
+    "\n",
+    "\n",
+    "ledger = [get_weather(\"boulder\", \"C\")]  # -> temperature -2\n",
+    "print(\"Ledger:\", ledger)\n",
+    "grounding_check(\"It's -2C in Boulder with snow — bundle up.\", ledger)\n",
+    "print(\"GROUNDED -> answer matches tool output\")\n",
+    "try:\n",
+    "    grounding_check(\"It's -20C in Boulder.\", ledger)  # fabricated figure\n",
+    "except GuardError as g:\n",
+    "    print(\"BLOCKED  ->\", g.guard, \"|\", g.detail)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ecee239",
+   "metadata": {},
+   "source": [
+    "## Putting it together: a guarded tool-calling loop\n",
+    "\n",
+    "Now we wire all four guards into a single loop around Grok. The `grok_chat` helper calls the real API\n",
+    "when `XAI_API_KEY` is set, and otherwise returns scripted responses so the loop runs offline. Notice\n",
+    "that **the guards are identical in both modes** — they're the deterministic core, and they never depend\n",
+    "on the network."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "38dedc16",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-23T16:39:54.918556Z",
+     "iopub.status.busy": "2026-07-23T16:39:54.918339Z",
+     "iopub.status.idle": "2026-07-23T16:39:54.928598Z",
+     "shell.execute_reply": "2026-07-23T16:39:54.927655Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FINAL ANSWER: It's -2C and snowing in Boulder — dress warmly.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "from dataclasses import dataclass, field\n",
+    "\n",
+    "\n",
+    "@dataclass\n",
+    "class ModelTurn:\n",
+    "    \"\"\"Normalized view of a model response: tool calls and/or final text.\"\"\"\n",
+    "    tool_calls: list[dict] = field(default_factory=list)  # [{id, name, arguments(str)}]\n",
+    "    content: str | None = None\n",
+    "\n",
+    "\n",
+    "def grok_chat(messages: list[dict]) -> ModelTurn:\n",
+    "    if LIVE:\n",
+    "        resp = client.chat.completions.create(\n",
+    "            model=MODEL, messages=messages, tools=tools_payload, tool_choice=\"auto\",\n",
+    "        )\n",
+    "        msg = resp.choices[0].message\n",
+    "        calls = [{\"id\": c.id, \"name\": c.function.name, \"arguments\": c.function.arguments}\n",
+    "                 for c in (msg.tool_calls or [])]\n",
+    "        return ModelTurn(tool_calls=calls, content=msg.content)\n",
+    "\n",
+    "    # OFFLINE DEMO: first turn -> ask for weather; after a tool result -> final answer.\n",
+    "    if not any(m.get(\"role\") == \"tool\" for m in messages):\n",
+    "        return ModelTurn(tool_calls=[{\"id\": \"call_1\", \"name\": \"get_weather\",\n",
+    "                                      \"arguments\": json.dumps({\"city\": \"boulder\", \"units\": \"C\"})}])\n",
+    "    temp = json.loads(messages[-1][\"content\"])[\"temperature\"]\n",
+    "    return ModelTurn(content=f\"It's {temp}C and snowing in Boulder — dress warmly.\")\n",
+    "\n",
+    "\n",
+    "def guarded_loop(user_prompt: str, auto_approved: set[str], max_turns: int = 4) -> str:\n",
+    "    messages = [{\"role\": \"user\", \"content\": user_prompt}]\n",
+    "    ledger: list[dict] = []\n",
+    "    for _ in range(max_turns):\n",
+    "        turn = grok_chat(messages)\n",
+    "\n",
+    "        if not turn.tool_calls:\n",
+    "            grounding_check(turn.content or \"\", ledger)  # Guard 4\n",
+    "            return turn.content or \"\"\n",
+    "\n",
+    "        messages.append({\"role\": \"assistant\", \"tool_calls\": [\n",
+    "            {\"id\": c[\"id\"], \"type\": \"function\",\n",
+    "             \"function\": {\"name\": c[\"name\"], \"arguments\": c[\"arguments\"]}} for c in turn.tool_calls]})\n",
+    "\n",
+    "        for call in turn.tool_calls:\n",
+    "            try:\n",
+    "                tier_gate(call[\"name\"], auto_approved)                       # Guard 2\n",
+    "                args = validate_args(call[\"name\"], json.loads(call[\"arguments\"]))  # Guard 1\n",
+    "                result = run_and_verify(call[\"name\"], args)                  # Guard 3\n",
+    "                ledger.append(result)\n",
+    "                payload = json.dumps(result)\n",
+    "            except GuardError as g:\n",
+    "                # Fail-closed: hand the structured error back so the model can recover.\n",
+    "                payload = json.dumps({\"error\": g.guard, \"detail\": g.detail})\n",
+    "            messages.append({\"role\": \"tool\", \"tool_call_id\": call[\"id\"], \"content\": payload})\n",
+    "    return \"stopped: max turns reached\"\n",
+    "\n",
+    "\n",
+    "answer = guarded_loop(\"What's the weather in Boulder and should I bundle up?\", auto_approved=set())\n",
+    "print(\"FINAL ANSWER:\", answer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8f7ce93",
+   "metadata": {},
+   "source": [
+    "## Recap\n",
+    "\n",
+    "Four deterministic, zero-token guards turn a raw Grok tool-calling loop into one that fails safely:\n",
+    "\n",
+    "1. **Argument validation** rejects malformed tool arguments before execution (fail-closed).\n",
+    "2. **Action-tier gate** blocks irreversible tools from auto-firing without explicit approval.\n",
+    "3. **Output verification** stops off-contract tool results from re-entering the model's context.\n",
+    "4. **Grounding check** flags final answers that cite numbers no tool actually returned.\n",
+    "\n",
+    "Because they're plain Python running *around* the model, they add no token cost, are fully\n",
+    "reproducible, and compose with any function-calling setup. Extend them with your own tiers (e.g. a\n",
+    "`spend` tier with a dollar-limit check), richer result contracts, or an approval UI behind the tier\n",
+    "gate.\n",
+    "\n",
+    "**Next steps:** set `XAI_API_KEY` (see `.env.example`) and re-run — the same guards now wrap live Grok\n",
+    "calls, unchanged."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/registry.yaml
+++ b/registry.yaml
@@ -82,3 +82,16 @@
     - Zhaohan Dong
   tags:
     - function-calling
+
+- title: "Deterministic Guardrails for Grok Tool Calls"
+  path: examples/deterministic_tool_call_guardrails/guide.ipynb
+  date: 2026-07-23
+  description: "Wrap Grok function calling in four zero-token, fail-closed checks: argument validation, an action-tier gate for irreversible tools, output verification, and a grounding check"
+  authors:
+    - Anton Dzyatkovsky
+  tags:
+    - function-calling
+    - structured-outputs
+    - guardrails
+    - reliability
+    - production


### PR DESCRIPTION
## Description
Summary:
- Adds `examples/deterministic_tool_call_guardrails/guide.ipynb` — a cookbook showing how to wrap a Grok function-calling loop in four **deterministic, zero-token, fail-closed** checks:
  1. **Argument validation** — reject hallucinated/malformed tool arguments (Pydantic, `extra="forbid"`) before execution.
  2. **Action-tier gate** — block *irreversible* tools (e.g. sending an alert) from auto-firing without explicit approval.
  3. **Output verification** — validate a tool's *result* against a declared schema before it re-enters the model's context.
  4. **Grounding check** — flag final answers that cite numbers no tool actually returned.
- Registers the notebook in `registry.yaml`.

Why this change matters:
- Function calling is powerful but has real production failure modes: bad arguments, unsafe auto-executed actions, and off-contract tool outputs. These guards catch all three **in plain Python around the model** — no extra LLM call, no token cost, fully reproducible. It's the safety layer that complements [Function Calling 101](https://github.com/xai-org/xai-cookbook/blob/main/examples/function_calling_101/guide.ipynb) (which teaches the loop itself).
- The notebook is **runnable end-to-end out of the box**: with `XAI_API_KEY` set it calls the live Grok API; without one it runs an clearly-labeled offline demo mode so the deterministic guards still execute against realistic inputs. Only [Pydantic](https://docs.pydantic.dev/) + the OpenAI SDK already used across this cookbook — no additional framework.
- Motivated by the request in issue #18 for deterministic function-call contracts; thanks to @rokoss21 for raising the topic. This recipe addresses that need dependency-free rather than adopting any specific framework.

## Type(s) of Change
- [x] New Content
- [ ] Content Improvement (e.g., enhancing existing content)
- [ ] Bug Fix
- [ ] Other

## Checklist
- [x] Read "How to Contribute" in `CONTRIBUTING.md`
- [x] Code follows style guidelines in "How to Contribute"
- [x] Included relevant dependencies
- [x] API key is not in committed files
- [x] Notebook runs end-to-end with cell outputs shown and no errors (verified with `pytest --nbmake`)
- [x] Added new notebook entry to `registry.yaml` (if PR adds a new notebook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)