### PR TITLE
[Content] Grounded RAG with Verifiable Citations (Grok)

### DIFF
--- a/examples/grounded_rag_with_citations/guide.ipynb
+++ b/examples/grounded_rag_with_citations/guide.ipynb
@@ -1,0 +1,504 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "12dc475b",
+   "metadata": {},
+   "source": [
+    "# Grounded RAG with Verifiable Citations (Grok)\n",
+    "\n",
+    "Retrieval-augmented generation (RAG) is supposed to keep a model honest by feeding it real sources. But\n",
+    "\"I gave it the documents\" is not the same as \"the answer is actually supported by them.\" Two failures\n",
+    "slip through constantly:\n",
+    "\n",
+    "- **Uncited claims** — the answer states a fact that appears in *none* of the retrieved chunks (the model\n",
+    "  filled a gap from memory).\n",
+    "- **Mis-cited claims** — the answer cites `[doc_3]`, but `doc_3` doesn't actually contain that fact.\n",
+    "\n",
+    "You can catch both with a **deterministic, zero-token verifier** that runs *after* Grok answers and\n",
+    "*before* you show the answer to a user. Every sentence must cite a chunk, and the cited chunk must\n",
+    "actually contain support for it. If it doesn't, we **fail closed** — regenerate or refuse — instead of\n",
+    "shipping a confident hallucination.\n",
+    "\n",
+    "This cookbook builds a small end-to-end grounded-RAG loop on Grok:\n",
+    "\n",
+    "1. **Retrieve** the most relevant chunks with a dependency-free lexical retriever.\n",
+    "2. **Generate** an answer that must cite its sources inline as `[chunk_id]`.\n",
+    "3. **Verify** — deterministically — that every claim is cited *and* each citation is genuinely\n",
+    "   supported by the chunk it points to.\n",
+    "4. **Repair or refuse** when verification fails.\n",
+    "\n",
+    "Everything but the model call is pure Python: no token cost, fully reproducible. It builds directly on\n",
+    "the *grounding check* idea from\n",
+    "[Deterministic Guardrails for Grok Tool Calls](../deterministic_tool_call_guardrails/guide.ipynb),\n",
+    "turning it into a full retrieval recipe.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b509d3b7",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Same OpenAI-compatible client the rest of the cookbook uses, pointed at the xAI endpoint. The retriever and verifier are pure Python, so this notebook runs end-to-end even without a key — in that case the model call falls back to a clearly-labeled offline demo response."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0905e28f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T13:13:53.858022Z",
+     "iopub.status.busy": "2026-07-31T13:13:53.857771Z",
+     "iopub.status.idle": "2026-07-31T13:13:54.529168Z",
+     "shell.execute_reply": "2026-07-31T13:13:54.527679Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%pip install openai python-dotenv --quiet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5703402c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T13:13:54.532348Z",
+     "iopub.status.busy": "2026-07-31T13:13:54.532015Z",
+     "iopub.status.idle": "2026-07-31T13:13:55.404175Z",
+     "shell.execute_reply": "2026-07-31T13:13:55.403137Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mode: OFFLINE DEMO (deterministic retriever + verifier run for real)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os, json, re\n",
+    "from dotenv import load_dotenv\n",
+    "from openai import OpenAI\n",
+    "\n",
+    "load_dotenv()\n",
+    "XAI_API_KEY = os.environ.get(\"XAI_API_KEY\", \"\")\n",
+    "MODEL = \"grok-4\"\n",
+    "LIVE = bool(XAI_API_KEY)\n",
+    "client = OpenAI(base_url=\"https://api.x.ai/v1\", api_key=XAI_API_KEY) if LIVE else None\n",
+    "print(\"Mode:\", \"LIVE (real Grok API)\" if LIVE else \"OFFLINE DEMO (deterministic retriever + verifier run for real)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e196d8d2",
+   "metadata": {},
+   "source": [
+    "## A tiny corpus\n",
+    "\n",
+    "For a self-contained example we use a handful of short chunks. In production these come from your\n",
+    "vector store or search index — the retriever and verifier below don't care where the chunks originate,\n",
+    "only that each has a stable `id` and some `text`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "50d76527",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T13:13:55.406265Z",
+     "iopub.status.busy": "2026-07-31T13:13:55.406057Z",
+     "iopub.status.idle": "2026-07-31T13:13:55.410357Z",
+     "shell.execute_reply": "2026-07-31T13:13:55.409427Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5 chunks loaded\n"
+     ]
+    }
+   ],
+   "source": [
+    "CORPUS = [\n",
+    "    {\"id\": \"grok_ctx\", \"text\": \"Grok 4 supports a context window of 256000 tokens.\"},\n",
+    "    {\"id\": \"grok_tools\", \"text\": \"Grok exposes function calling via an OpenAI-compatible API at https://api.x.ai/v1.\"},\n",
+    "    {\"id\": \"grok_stream\", \"text\": \"Responses from the xAI API can be streamed incrementally by setting stream=True.\"},\n",
+    "    {\"id\": \"grok_struct\", \"text\": \"Structured outputs let you constrain Grok to return JSON that matches a schema.\"},\n",
+    "    {\"id\": \"unrelated\", \"text\": \"The Eiffel Tower is located in Paris and was completed in 1889.\"},\n",
+    "]\n",
+    "CHUNKS = {c[\"id\"]: c[\"text\"] for c in CORPUS}\n",
+    "print(f\"{len(CORPUS)} chunks loaded\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9345f2ad",
+   "metadata": {},
+   "source": [
+    "## Step 1 — Retrieve (dependency-free)\n",
+    "\n",
+    "A production system would use embeddings; to keep this notebook to a single `pip install` we use a\n",
+    "simple lexical overlap score. Swap this function for your vector search — nothing downstream changes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e2294746",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T13:13:55.412429Z",
+     "iopub.status.busy": "2026-07-31T13:13:55.412169Z",
+     "iopub.status.idle": "2026-07-31T13:13:55.417482Z",
+     "shell.execute_reply": "2026-07-31T13:13:55.416625Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [grok_ctx] Grok 4 supports a context window of 256000 tokens.\n",
+      "  [grok_tools] Grok exposes function calling via an OpenAI-compatible API at https://api.x.ai/v1.\n",
+      "  [grok_struct] Structured outputs let you constrain Grok to return JSON that matches a schema.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def tokenize(s: str) -> set[str]:\n",
+    "    return set(re.findall(r\"[a-z0-9]+\", s.lower()))\n",
+    "\n",
+    "\n",
+    "def retrieve(query: str, k: int = 3) -> list[dict]:\n",
+    "    # Score on content words only (drop short/function words) so an off-topic query retrieves nothing.\n",
+    "    q = {w for w in tokenize(query) if len(w) > 3}\n",
+    "    scored = [(len(q & tokenize(c[\"text\"])), c) for c in CORPUS]\n",
+    "    scored = [(s, c) for s, c in scored if s > 0]\n",
+    "    scored.sort(key=lambda x: x[0], reverse=True)\n",
+    "    return [c for _, c in scored[:k]]\n",
+    "\n",
+    "\n",
+    "retrieved = retrieve(\"How big is Grok's context window and how do I call tools?\")\n",
+    "for c in retrieved:\n",
+    "    print(f\"  [{c['id']}] {c['text']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c49d2108",
+   "metadata": {},
+   "source": [
+    "## Step 2 — Generate with mandatory inline citations\n",
+    "\n",
+    "We instruct Grok to answer **only** from the retrieved chunks and to tag every sentence with the\n",
+    "`[chunk_id]` it came from. The chunk ids are part of the prompt, so the model has a closed vocabulary of\n",
+    "citations to choose from."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "7c644d4c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T13:13:55.419543Z",
+     "iopub.status.busy": "2026-07-31T13:13:55.419334Z",
+     "iopub.status.idle": "2026-07-31T13:13:55.424646Z",
+     "shell.execute_reply": "2026-07-31T13:13:55.423772Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Grok 4 supports a context window of 256000 tokens [grok_ctx]. You call tools through an OpenAI-compatible API at https://api.x.ai/v1 [grok_tools].\n"
+     ]
+    }
+   ],
+   "source": [
+    "SYSTEM = (\n",
+    "    \"You answer strictly from the provided sources. Every sentence MUST end with a citation of the form \"\n",
+    "    \"[chunk_id] naming the source it came from. Use ONLY the chunk ids provided. If the sources do not \"\n",
+    "    \"contain the answer, reply exactly: INSUFFICIENT EVIDENCE.\"\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def build_context(chunks: list[dict]) -> str:\n",
+    "    return \"\\n\".join(f\"[{c['id']}] {c['text']}\" for c in chunks)\n",
+    "\n",
+    "\n",
+    "def grok_answer(query: str, chunks: list[dict]) -> str:\n",
+    "    context = build_context(chunks)\n",
+    "    user = f\"Sources:\\n{context}\\n\\nQuestion: {query}\\nAnswer with inline [chunk_id] citations.\"\n",
+    "    if LIVE:\n",
+    "        resp = client.chat.completions.create(\n",
+    "            model=MODEL,\n",
+    "            messages=[{\"role\": \"system\", \"content\": SYSTEM}, {\"role\": \"user\", \"content\": user}],\n",
+    "            temperature=0,\n",
+    "        )\n",
+    "        return resp.choices[0].message.content\n",
+    "    # OFFLINE DEMO: a well-formed, cited answer grounded in the retrieved chunks.\n",
+    "    return (\"Grok 4 supports a context window of 256000 tokens [grok_ctx]. \"\n",
+    "            \"You call tools through an OpenAI-compatible API at https://api.x.ai/v1 [grok_tools].\")\n",
+    "\n",
+    "\n",
+    "query = \"How big is Grok's context window and how do I call tools?\"\n",
+    "answer = grok_answer(query, retrieved)\n",
+    "print(answer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c24cfd5",
+   "metadata": {},
+   "source": [
+    "## Step 3 — Verify citations deterministically (zero tokens)\n",
+    "\n",
+    "This is the heart of the recipe. For every sentence in the answer we check:\n",
+    "\n",
+    "1. **It has a citation** — an uncited factual sentence is rejected.\n",
+    "2. **The cited id exists** — no citing a chunk that wasn't retrieved.\n",
+    "3. **The citation is supported** — the sentence's salient content words must actually appear in the\n",
+    "   cited chunk. This is what turns a *citation* into a *verifiable* citation: it catches the model\n",
+    "   tagging a real chunk id onto a claim that chunk doesn't support.\n",
+    "\n",
+    "The check is lexical and intentionally simple — it's a fast, free tripwire, not a proof. Tighten it\n",
+    "(exact-span quoting, entailment models) as your risk profile demands."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "405fa40a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T13:13:55.426745Z",
+     "iopub.status.busy": "2026-07-31T13:13:55.426540Z",
+     "iopub.status.idle": "2026-07-31T13:13:55.433488Z",
+     "shell.execute_reply": "2026-07-31T13:13:55.432607Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Verifying the model's answer...\n",
+      "   OK - fully grounded\n"
+     ]
+    }
+   ],
+   "source": [
+    "STOPWORDS = set(\"a an the of to and or is are was were be been being in on at for with by from as \"\n",
+    "                \"how do i you it this that these those can does support supports via using use\".split())\n",
+    "\n",
+    "\n",
+    "def salient(sentence: str) -> set[str]:\n",
+    "    return {w for w in tokenize(sentence) if w not in STOPWORDS and len(w) > 2}\n",
+    "\n",
+    "\n",
+    "def verify_answer(answer: str, chunks: dict[str, str]) -> list[str]:\n",
+    "    \"\"\"Return a list of problems. Empty list == the answer is fully grounded.\"\"\"\n",
+    "    if answer.strip() == \"INSUFFICIENT EVIDENCE\":\n",
+    "        return []\n",
+    "    problems = []\n",
+    "    # split into sentences, keeping each sentence's trailing citations\n",
+    "    sentences = [s.strip() for s in re.split(r\"(?<=[.!?])\\s+\", answer) if s.strip()]\n",
+    "    for sent in sentences:\n",
+    "        cited = re.findall(r\"\\[([a-z0-9_]+)\\]\", sent)\n",
+    "        claim = re.sub(r\"\\[[a-z0-9_]+\\]\", \"\", sent)\n",
+    "        if not cited:\n",
+    "            problems.append(f\"UNCITED: {claim.strip()!r}\")\n",
+    "            continue\n",
+    "        terms = salient(claim)\n",
+    "        for cid in cited:\n",
+    "            if cid not in chunks:\n",
+    "                problems.append(f\"BAD_ID: [{cid}] is not a retrieved chunk\")\n",
+    "                continue\n",
+    "            support = tokenize(chunks[cid])\n",
+    "            # every citation must cover the majority of the claim's salient terms\n",
+    "            covered = terms & support\n",
+    "            if terms and len(covered) / len(terms) < 0.5:\n",
+    "                problems.append(f\"UNSUPPORTED: {claim.strip()!r} -> [{cid}] \"\n",
+    "                                f\"(covers {len(covered)}/{len(terms)} key terms)\")\n",
+    "    return problems\n",
+    "\n",
+    "\n",
+    "print(\"Verifying the model's answer...\")\n",
+    "for p in verify_answer(answer, CHUNKS) or [\"OK - fully grounded\"]:\n",
+    "    print(\"  \", p)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58133f1b",
+   "metadata": {},
+   "source": [
+    "### The verifier earns its keep\n",
+    "\n",
+    "Watch it reject three answers a naive pipeline would happily return: an uncited claim, a fabricated citation id, and a claim tagged onto a real-but-unrelated chunk."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9ecc44a5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T13:13:55.435462Z",
+     "iopub.status.busy": "2026-07-31T13:13:55.435246Z",
+     "iopub.status.idle": "2026-07-31T13:13:55.439284Z",
+     "shell.execute_reply": "2026-07-31T13:13:55.438517Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "uncited fact:\n",
+      "   BLOCKED -> UNCITED: 'Grok 4 supports a context window of 256000 tokens.'\n",
+      "hallucinated id:\n",
+      "   BLOCKED -> BAD_ID: [local_only] is not a retrieved chunk\n",
+      "mis-cited claim:\n",
+      "   BLOCKED -> UNSUPPORTED: 'The Eiffel Tower is 330 meters tall .' -> [grok_ctx] (covers 0/5 key terms)\n"
+     ]
+    }
+   ],
+   "source": [
+    "bad_answers = {\n",
+    "    \"uncited fact\":       \"Grok 4 supports a context window of 256000 tokens.\",\n",
+    "    \"hallucinated id\":    \"Grok runs entirely on-device [local_only].\",\n",
+    "    \"mis-cited claim\":    \"The Eiffel Tower is 330 meters tall [grok_ctx].\",\n",
+    "}\n",
+    "for label, a in bad_answers.items():\n",
+    "    print(f\"{label}:\")\n",
+    "    for p in verify_answer(a, CHUNKS):\n",
+    "        print(\"   BLOCKED ->\", p)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4739771a",
+   "metadata": {},
+   "source": [
+    "## Step 4 — The full grounded-RAG loop (retrieve → generate → verify → repair/refuse)\n",
+    "\n",
+    "We tie it together with a fail-closed policy: if the answer doesn't verify, we make one bounded repair\n",
+    "attempt (re-ask, feeding the verifier's complaints back to the model), and if it still fails we refuse\n",
+    "rather than show an ungrounded answer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "3c5ec849",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T13:13:55.441575Z",
+     "iopub.status.busy": "2026-07-31T13:13:55.441366Z",
+     "iopub.status.idle": "2026-07-31T13:13:55.447441Z",
+     "shell.execute_reply": "2026-07-31T13:13:55.446367Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Q1: Grok 4 supports a context window of 256000 tokens [grok_ctx]. You call tools through an OpenAI-compatible API at https://api.x.ai/v1 [grok_tools].\n",
+      "\n",
+      "Q2: INSUFFICIENT EVIDENCE (nothing retrieved)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def grounded_rag(query: str, max_repairs: int = 1) -> str:\n",
+    "    chunks = retrieve(query)\n",
+    "    if not chunks:\n",
+    "        return \"INSUFFICIENT EVIDENCE (nothing retrieved)\"\n",
+    "    answer = grok_answer(query, chunks)\n",
+    "    for attempt in range(max_repairs + 1):\n",
+    "        problems = verify_answer(answer, {c[\"id\"]: c[\"text\"] for c in chunks})\n",
+    "        if not problems:\n",
+    "            return answer\n",
+    "        if attempt == max_repairs:\n",
+    "            # Fail closed: never return an answer we could not verify.\n",
+    "            return \"REFUSED: answer failed citation verification -> \" + \" | \".join(problems)\n",
+    "        # Bounded repair: hand the complaints back and regenerate (LIVE mode only; offline is fixed).\n",
+    "        if LIVE:\n",
+    "            fix = (f\"Your previous answer had grounding problems: {problems}. \"\n",
+    "                   f\"Rewrite it, citing only supported chunks, or say INSUFFICIENT EVIDENCE.\")\n",
+    "            resp = client.chat.completions.create(\n",
+    "                model=MODEL,\n",
+    "                messages=[{\"role\": \"system\", \"content\": SYSTEM},\n",
+    "                          {\"role\": \"user\", \"content\": f\"Sources:\\n{build_context(chunks)}\\n\\n{fix}\"}],\n",
+    "                temperature=0)\n",
+    "            answer = resp.choices[0].message.content\n",
+    "        else:\n",
+    "            break\n",
+    "    return answer\n",
+    "\n",
+    "\n",
+    "print(\"Q1:\", grounded_rag(\"How big is Grok's context window and how do I call tools?\"))\n",
+    "print()\n",
+    "print(\"Q2:\", grounded_rag(\"What is the airspeed velocity of an unladen swallow?\"))  # not in corpus -> refuse/insufficient"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f564f3c5",
+   "metadata": {},
+   "source": [
+    "## Recap\n",
+    "\n",
+    "A grounded-RAG pipeline is only as trustworthy as its weakest citation. Three deterministic pieces make\n",
+    "Grok's answers auditable at zero token cost:\n",
+    "\n",
+    "1. **Retrieve** relevant chunks (swap in your own vector search).\n",
+    "2. **Generate** with a closed vocabulary of `[chunk_id]` citations.\n",
+    "3. **Verify** that every claim is cited *and* genuinely supported by its chunk — then **fail closed**,\n",
+    "   repairing once or refusing rather than shipping an ungrounded answer.\n",
+    "\n",
+    "Because the verifier is plain Python, it costs nothing to run on every response, is fully reproducible,\n",
+    "and gives you an audit trail of exactly which source backs each sentence. Harden it with span-level\n",
+    "quoting or an entailment model where the stakes are high.\n",
+    "\n",
+    "**Next steps:** set `XAI_API_KEY` (see `.env.example`) and re-run — the same retriever and verifier now\n",
+    "wrap live Grok answers, and the repair loop re-asks the model when a citation doesn't hold up."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/registry.yaml
+++ b/registry.yaml
@@ -82,3 +82,15 @@
     - Zhaohan Dong
   tags:
     - function-calling
+- title: "Grounded RAG with Verifiable Citations (Grok)"
+  path: examples/grounded_rag_with_citations/guide.ipynb
+  date: 2026-07-24
+  description: "Build a grounded RAG loop on Grok where a deterministic zero-token verifier checks that every sentence is cited AND each citation is genuinely supported by its chunk, failing closed on hallucinated or mis-cited claims"
+  authors:
+    - Anton Dzyatkovsky
+  tags:
+    - rag
+    - citations
+    - retrieval
+    - structured-outputs
+    - reliability


### PR DESCRIPTION
## Description
Summary:
- Adds `examples/grounded_rag_with_citations/guide.ipynb` — a small, end-to-end **grounded RAG** loop on Grok with a **deterministic, zero-token citation verifier**:
  1. **Retrieve** relevant chunks (dependency-free lexical retriever; swap in your vector search).
  2. **Generate** an answer that must cite every sentence with an inline `[chunk_id]` from a closed vocabulary.
  3. **Verify** — in pure Python — that every claim is cited **and** each cited chunk actually *supports* the claim (not just that a citation exists).
  4. **Fail closed** — one bounded repair attempt, else refuse — instead of shipping an ungrounded answer.
- Registers the notebook in `registry.yaml`.

Why this change matters:
- RAG's whole promise is grounded answers, yet uncited and mis-cited claims slip through constantly. This recipe makes each answer **auditable at zero token cost** — you get a per-sentence map of which source backs it, and hallucinations are blocked before a user sees them. There is currently no RAG example in the cookbook; this fills that gap.
- Runs **end-to-end out of the box**: with `XAI_API_KEY` set it calls live Grok (and the repair loop re-asks the model when a citation doesn't hold up); without a key it runs a clearly-labeled offline demo so the retriever and verifier still execute for real. Only Pydantic-free stdlib + the OpenAI SDK already used across this cookbook.
- Complements [Deterministic Guardrails for Grok Tool Calls](https://github.com/xai-org/xai-cookbook/pull/45): that PR introduced a grounding check for tool outputs; this turns the same idea into a full retrieval recipe.

## Type(s) of Change
- [x] New Content
- [ ] Content Improvement (e.g., enhancing existing content)
- [ ] Bug Fix
- [ ] Other

## Checklist
- [x] Read "How to Contribute" in `CONTRIBUTING.md`
- [x] Code follows style guidelines in "How to Contribute"
- [x] Included relevant dependencies
- [x] API key is not in committed files
- [x] Notebook runs end-to-end with cell outputs shown and no errors (verified with `pytest --nbmake`)
- [x] Added new notebook entry to `registry.yaml` (if PR adds a new notebook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)