### PR TITLE
[Content] Evaluating Grok Applications: Deterministic Checks + LLM-as-Judge

### DIFF
--- a/examples/evaluating_grok_applications/guide.ipynb
+++ b/examples/evaluating_grok_applications/guide.ipynb
@@ -1,0 +1,588 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f5b93ae1",
+   "metadata": {},
+   "source": [
+    "# Evaluating Grok Applications: Deterministic Checks + LLM-as-Judge\n",
+    "\n",
+    "\"It looked good when I tried it\" is not an evaluation. The moment you change a prompt, swap a model\n",
+    "version, or raise the temperature, you need a way to answer one question: **did this get better or\n",
+    "worse?**\n",
+    "\n",
+    "This cookbook builds a small but complete evaluation harness for a Grok application. The key idea is a\n",
+    "**two-tier judging strategy**:\n",
+    "\n",
+    "| Tier | Cost | Use it for |\n",
+    "|------|------|-----------|\n",
+    "| **1. Deterministic checks** | 0 tokens, instant | anything with a right answer — format, schema, required content, forbidden content, latency |\n",
+    "| **2. LLM-as-judge (Grok)** | 1 call per case | genuinely subjective qualities — tone, helpfulness, faithfulness |\n",
+    "\n",
+    "Run tier 1 first and let it **short-circuit**: if an output isn't even valid JSON, don't spend a judge\n",
+    "call asking whether its tone is friendly. Most regressions are caught for free, and you only pay the\n",
+    "model where human-like judgment is genuinely required.\n",
+    "\n",
+    "**What you'll build**\n",
+    "\n",
+    "1. An **eval dataset** — cases with inputs and expectations.\n",
+    "2. **Deterministic graders** — schema, required/forbidden terms, exact match.\n",
+    "3. An **LLM judge** on Grok with a strict rubric and structured output.\n",
+    "4. A **scored run** with a pass/fail gate and a **regression comparison** between two variants.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7fb3d6e",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "We use the same OpenAI-compatible client as the rest of the cookbook. The deterministic graders are pure Python, so the whole harness runs even without an API key — the app and judge then fall back to clearly-labeled offline stand-ins."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0953c192",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T05:31:07.687548Z",
+     "iopub.status.busy": "2026-08-01T05:31:07.686739Z",
+     "iopub.status.idle": "2026-08-01T05:31:08.990939Z",
+     "shell.execute_reply": "2026-08-01T05:31:08.987892Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%pip install openai pydantic python-dotenv --quiet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5fe055aa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T05:31:08.998124Z",
+     "iopub.status.busy": "2026-08-01T05:31:08.997451Z",
+     "iopub.status.idle": "2026-08-01T05:31:11.614337Z",
+     "shell.execute_reply": "2026-08-01T05:31:11.610497Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mode: OFFLINE DEMO (deterministic graders run for real)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os, json, re, time\n",
+    "from dotenv import load_dotenv\n",
+    "from openai import OpenAI\n",
+    "\n",
+    "load_dotenv()\n",
+    "XAI_API_KEY = os.environ.get(\"XAI_API_KEY\", \"\")\n",
+    "MODEL = \"grok-4\"\n",
+    "LIVE = bool(XAI_API_KEY)\n",
+    "client = OpenAI(base_url=\"https://api.x.ai/v1\", api_key=XAI_API_KEY) if LIVE else None\n",
+    "print(\"Mode:\", \"LIVE (real Grok API)\" if LIVE else \"OFFLINE DEMO (deterministic graders run for real)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf2b8937",
+   "metadata": {},
+   "source": [
+    "## Step 1 — The eval dataset\n",
+    "\n",
+    "An eval set is just cases: an input, plus what a good answer must satisfy. Keep expectations\n",
+    "**machine-checkable** wherever you can — that's what makes tier 1 free.\n",
+    "\n",
+    "Our toy application is a support-ticket classifier that must return strict JSON."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "19cd8f4b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T05:31:11.621091Z",
+     "iopub.status.busy": "2026-08-01T05:31:11.620638Z",
+     "iopub.status.idle": "2026-08-01T05:31:11.631532Z",
+     "shell.execute_reply": "2026-08-01T05:31:11.628532Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3 eval cases\n"
+     ]
+    }
+   ],
+   "source": [
+    "EVAL_CASES = [\n",
+    "    {\n",
+    "        \"id\": \"billing_refund\",\n",
+    "        \"input\": \"I was charged twice for my subscription this month. I want one charge refunded.\",\n",
+    "        \"expect_category\": \"billing\",\n",
+    "        \"must_include\": [\"refund\"],\n",
+    "        \"must_not_include\": [\"password\"],\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"login_2fa\",\n",
+    "        \"input\": \"I can't log in, the two-factor code never arrives on my phone.\",\n",
+    "        \"expect_category\": \"account_access\",\n",
+    "        \"must_include\": [\"login\"],\n",
+    "        \"must_not_include\": [\"refund\"],\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"bug_export\",\n",
+    "        \"input\": \"Exporting a CSV crashes the dashboard every time I click export.\",\n",
+    "        \"expect_category\": \"bug\",\n",
+    "        \"must_include\": [\"export\"],\n",
+    "        \"must_not_include\": [\"refund\"],\n",
+    "    },\n",
+    "]\n",
+    "print(f\"{len(EVAL_CASES)} eval cases\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7e1ff1a",
+   "metadata": {},
+   "source": [
+    "## Step 2 — The application under test\n",
+    "\n",
+    "The thing we're evaluating: a classifier prompted to return strict JSON with a category, a summary, and\n",
+    "a suggested reply. In offline mode we return two *variants* of canned outputs so the regression\n",
+    "comparison later has something real to compare — variant `b` deliberately has a defect."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b8a0b1a5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T05:31:11.639028Z",
+     "iopub.status.busy": "2026-08-01T05:31:11.638445Z",
+     "iopub.status.idle": "2026-08-01T05:31:11.654973Z",
+     "shell.execute_reply": "2026-08-01T05:31:11.651851Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"category\":\"billing\",\"summary\":\"Duplicate charge this month\",\"reply\":\"Sorry about that - I have issued a refund for the duplicate charge.\"}\n"
+     ]
+    }
+   ],
+   "source": [
+    "SYSTEM = (\n",
+    "    \"You triage support tickets. Reply with ONLY a JSON object: \"\n",
+    "    '{\"category\": one of [\"billing\",\"account_access\",\"bug\",\"other\"], '\n",
+    "    '\"summary\": string, \"reply\": string}. No prose outside the JSON.'\n",
+    ")\n",
+    "\n",
+    "OFFLINE = {\n",
+    "    \"a\": {  # the good variant\n",
+    "        \"billing_refund\": '{\"category\":\"billing\",\"summary\":\"Duplicate charge this month\",\"reply\":\"Sorry about that - I have issued a refund for the duplicate charge.\"}',\n",
+    "        \"login_2fa\": '{\"category\":\"account_access\",\"summary\":\"2FA code not arriving\",\"reply\":\"Let us fix your login - I can resend the two-factor code.\"}',\n",
+    "        \"bug_export\": '{\"category\":\"bug\",\"summary\":\"CSV export crashes dashboard\",\"reply\":\"Thanks for reporting - the export crash is now with our engineers.\"}',\n",
+    "    },\n",
+    "    \"b\": {  # the regressed variant: one wrong category + one non-JSON answer\n",
+    "        \"billing_refund\": '{\"category\":\"other\",\"summary\":\"Customer mentions a charge\",\"reply\":\"We have received your refund request.\"}',\n",
+    "        \"login_2fa\": \"Sure! I can help you with your login problem.\",  # not JSON at all\n",
+    "        \"bug_export\": '{\"category\":\"bug\",\"summary\":\"CSV export crashes dashboard\",\"reply\":\"Thanks for reporting - the export crash is now with our engineers.\"}',\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def run_app(case: dict, variant: str = \"a\", temperature: float = 0.0) -> str:\n",
+    "    if LIVE:\n",
+    "        resp = client.chat.completions.create(\n",
+    "            model=MODEL, temperature=temperature,\n",
+    "            messages=[{\"role\": \"system\", \"content\": SYSTEM},\n",
+    "                      {\"role\": \"user\", \"content\": case[\"input\"]}])\n",
+    "        return resp.choices[0].message.content\n",
+    "    return OFFLINE[variant][case[\"id\"]]\n",
+    "\n",
+    "\n",
+    "print(run_app(EVAL_CASES[0]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ae5e282",
+   "metadata": {},
+   "source": [
+    "## Step 3 — Tier 1: deterministic graders (zero tokens)\n",
+    "\n",
+    "These are the checks with an objectively right answer. They cost nothing, never flake, and catch the\n",
+    "majority of real regressions: broken JSON, wrong label, missing required content, leaked forbidden\n",
+    "content.\n",
+    "\n",
+    "Each grader returns `(passed, detail)` so failures are self-explaining in the report."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "bef437f1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T05:31:11.661221Z",
+     "iopub.status.busy": "2026-08-01T05:31:11.660603Z",
+     "iopub.status.idle": "2026-08-01T05:31:11.684743Z",
+     "shell.execute_reply": "2026-08-01T05:31:11.681489Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "good:\n",
+      "   PASS  grade_valid_json   valid JSON\n",
+      "   PASS  grade_schema       schema ok\n",
+      "   PASS  grade_category     expected 'account_access', got 'account_access'\n",
+      "   PASS  grade_content      content ok\n",
+      "regressed:\n",
+      "   FAIL  grade_valid_json   invalid JSON: Expecting value\n",
+      "   FAIL  grade_schema       unparseable\n",
+      "   FAIL  grade_category     unparseable\n",
+      "   PASS  grade_content      content ok\n"
+     ]
+    }
+   ],
+   "source": [
+    "def grade_valid_json(output: str, case: dict) -> tuple[bool, str]:\n",
+    "    try:\n",
+    "        json.loads(output)\n",
+    "        return True, \"valid JSON\"\n",
+    "    except json.JSONDecodeError as e:\n",
+    "        return False, f\"invalid JSON: {e.msg}\"\n",
+    "\n",
+    "\n",
+    "def grade_schema(output: str, case: dict) -> tuple[bool, str]:\n",
+    "    try:\n",
+    "        obj = json.loads(output)\n",
+    "    except json.JSONDecodeError:\n",
+    "        return False, \"unparseable\"\n",
+    "    required = {\"category\", \"summary\", \"reply\"}\n",
+    "    missing = required - obj.keys()\n",
+    "    if missing:\n",
+    "        return False, f\"missing keys: {sorted(missing)}\"\n",
+    "    if obj[\"category\"] not in {\"billing\", \"account_access\", \"bug\", \"other\"}:\n",
+    "        return False, f\"category not in enum: {obj['category']!r}\"\n",
+    "    return True, \"schema ok\"\n",
+    "\n",
+    "\n",
+    "def grade_category(output: str, case: dict) -> tuple[bool, str]:\n",
+    "    try:\n",
+    "        got = json.loads(output).get(\"category\")\n",
+    "    except json.JSONDecodeError:\n",
+    "        return False, \"unparseable\"\n",
+    "    want = case[\"expect_category\"]\n",
+    "    return (got == want), f\"expected {want!r}, got {got!r}\"\n",
+    "\n",
+    "\n",
+    "def grade_content(output: str, case: dict) -> tuple[bool, str]:\n",
+    "    low = output.lower()\n",
+    "    for term in case.get(\"must_include\", []):\n",
+    "        if term not in low:\n",
+    "            return False, f\"missing required term {term!r}\"\n",
+    "    for term in case.get(\"must_not_include\", []):\n",
+    "        if term in low:\n",
+    "            return False, f\"contains forbidden term {term!r}\"\n",
+    "    return True, \"content ok\"\n",
+    "\n",
+    "\n",
+    "DETERMINISTIC = [grade_valid_json, grade_schema, grade_category, grade_content]\n",
+    "\n",
+    "# Demo on one good and one broken output:\n",
+    "for label, out in [(\"good\", OFFLINE[\"a\"][\"login_2fa\"]), (\"regressed\", OFFLINE[\"b\"][\"login_2fa\"])]:\n",
+    "    print(f\"{label}:\")\n",
+    "    for g in DETERMINISTIC:\n",
+    "        ok, detail = g(out, EVAL_CASES[1])\n",
+    "        print(f\"   {'PASS' if ok else 'FAIL'}  {g.__name__:<18} {detail}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56be28e1",
+   "metadata": {},
+   "source": [
+    "## Step 4 — Tier 2: LLM-as-judge on Grok\n",
+    "\n",
+    "Some qualities have no regex: is the reply *actually helpful*? Is the tone right for a frustrated\n",
+    "customer? For these we ask Grok to score the output against a **strict rubric** and return structured\n",
+    "JSON.\n",
+    "\n",
+    "Three practices keep judges trustworthy:\n",
+    "\n",
+    "* **A narrow rubric with explicit anchors** — vague criteria produce vague, drifting scores.\n",
+    "* **`temperature=0` and structured output** — the judge should be as reproducible as we can make it.\n",
+    "* **Require a reason** — a score without a justification is unreviewable, and reading the reasons is how\n",
+    "  you discover the judge itself is wrong."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "5e8c3465",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T05:31:11.691605Z",
+     "iopub.status.busy": "2026-08-01T05:31:11.690984Z",
+     "iopub.status.idle": "2026-08-01T05:31:11.709016Z",
+     "shell.execute_reply": "2026-08-01T05:31:11.704962Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'helpfulness': 4, 'tone': 5, 'reason': 'offline demo heuristic stand-in for a real Grok judgement'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "JUDGE_SYSTEM = (\n",
+    "    \"You are a strict evaluator. Score the assistant's support reply on two criteria, 1-5:\\n\"\n",
+    "    \"  helpfulness: 5 = directly resolves the user's problem; 3 = partially useful; 1 = no real help.\\n\"\n",
+    "    \"  tone: 5 = warm and professional; 3 = neutral/robotic; 1 = dismissive or rude.\\n\"\n",
+    "    'Reply with ONLY JSON: {\"helpfulness\": int, \"tone\": int, \"reason\": string}.'\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def llm_judge(ticket: str, reply: str) -> dict:\n",
+    "    if LIVE:\n",
+    "        resp = client.chat.completions.create(\n",
+    "            model=MODEL, temperature=0,\n",
+    "            messages=[{\"role\": \"system\", \"content\": JUDGE_SYSTEM},\n",
+    "                      {\"role\": \"user\", \"content\": f\"Ticket: {ticket}\\n\\nAssistant reply: {reply}\"}])\n",
+    "        try:\n",
+    "            return json.loads(resp.choices[0].message.content)\n",
+    "        except json.JSONDecodeError:\n",
+    "            return {\"helpfulness\": 0, \"tone\": 0, \"reason\": \"judge returned non-JSON\"}\n",
+    "    # OFFLINE DEMO: a scripted judgement so the harness runs end-to-end.\n",
+    "    warm = any(w in reply.lower() for w in [\"sorry\", \"thanks\", \"let us\", \"happy\"])\n",
+    "    return {\"helpfulness\": 4 if len(reply) > 40 else 2,\n",
+    "            \"tone\": 5 if warm else 3,\n",
+    "            \"reason\": \"offline demo heuristic stand-in for a real Grok judgement\"}\n",
+    "\n",
+    "\n",
+    "print(llm_judge(EVAL_CASES[0][\"input\"], json.loads(OFFLINE[\"a\"][\"billing_refund\"])[\"reply\"]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c020765",
+   "metadata": {},
+   "source": [
+    "## Step 5 — The harness: short-circuit, score, gate\n",
+    "\n",
+    "Now the two tiers combine. Deterministic checks run first; **if any fails, we skip the judge entirely** —\n",
+    "there's no point paying to rate the tone of malformed output. That single rule is what keeps an eval\n",
+    "suite cheap as it grows.\n",
+    "\n",
+    "We gate on two thresholds: deterministic checks must pass 100% (they're objective), and judged scores\n",
+    "must clear a quality bar."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "7bd237a8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T05:31:11.716116Z",
+     "iopub.status.busy": "2026-08-01T05:31:11.715348Z",
+     "iopub.status.idle": "2026-08-01T05:31:11.739204Z",
+     "shell.execute_reply": "2026-08-01T05:31:11.736151Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== variant a ===\n",
+      "deterministic: 3/3 passed | judge calls: 3 (saved 0) | avg judged score: 4.5\n",
+      "  PASS billing_refund   score=4.5\n",
+      "  PASS login_2fa        score=4.5\n",
+      "  PASS bug_export       score=4.5\n",
+      "GATE: PASS ✅\n"
+     ]
+    }
+   ],
+   "source": [
+    "JUDGE_THRESHOLD = 3.5\n",
+    "\n",
+    "\n",
+    "def evaluate(variant: str, cases=EVAL_CASES) -> dict:\n",
+    "    rows, judge_calls = [], 0\n",
+    "    for case in cases:\n",
+    "        t0 = time.perf_counter()\n",
+    "        output = run_app(case, variant=variant)\n",
+    "        latency_ms = (time.perf_counter() - t0) * 1000\n",
+    "\n",
+    "        failures = []\n",
+    "        for g in DETERMINISTIC:\n",
+    "            ok, detail = g(output, case)\n",
+    "            if not ok:\n",
+    "                failures.append(f\"{g.__name__}: {detail}\")\n",
+    "\n",
+    "        judged = None\n",
+    "        if not failures:  # short-circuit: only judge outputs that are objectively well-formed\n",
+    "            reply = json.loads(output)[\"reply\"]\n",
+    "            judged = llm_judge(case[\"input\"], reply)\n",
+    "            judge_calls += 1\n",
+    "\n",
+    "        rows.append({\"case\": case[\"id\"], \"failures\": failures, \"judged\": judged,\n",
+    "                     \"latency_ms\": round(latency_ms, 1)})\n",
+    "\n",
+    "    det_pass = sum(1 for r in rows if not r[\"failures\"])\n",
+    "    scores = [ (r[\"judged\"][\"helpfulness\"] + r[\"judged\"][\"tone\"]) / 2\n",
+    "               for r in rows if r[\"judged\"] ]\n",
+    "    avg = round(sum(scores) / len(scores), 2) if scores else 0.0\n",
+    "    return {\"variant\": variant, \"rows\": rows, \"det_pass\": det_pass, \"total\": len(cases),\n",
+    "            \"avg_score\": avg, \"judge_calls\": judge_calls}\n",
+    "\n",
+    "\n",
+    "def report(res: dict) -> None:\n",
+    "    print(f\"=== variant {res['variant']} ===\")\n",
+    "    print(f\"deterministic: {res['det_pass']}/{res['total']} passed | \"\n",
+    "          f\"judge calls: {res['judge_calls']} (saved {res['total'] - res['judge_calls']}) | \"\n",
+    "          f\"avg judged score: {res['avg_score']}\")\n",
+    "    for r in res[\"rows\"]:\n",
+    "        status = \"PASS\" if not r[\"failures\"] else \"FAIL\"\n",
+    "        extra = \"\" if r[\"failures\"] else f\" score={(r['judged']['helpfulness'] + r['judged']['tone']) / 2}\"\n",
+    "        print(f\"  {status} {r['case']:<16}{extra}\")\n",
+    "        for f in r[\"failures\"]:\n",
+    "            print(f\"        - {f}\")\n",
+    "    gate = res[\"det_pass\"] == res[\"total\"] and res[\"avg_score\"] >= JUDGE_THRESHOLD\n",
+    "    print(\"GATE:\", \"PASS ✅\" if gate else \"FAIL ❌\")\n",
+    "\n",
+    "\n",
+    "baseline = evaluate(\"a\")\n",
+    "report(baseline)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7bb74028",
+   "metadata": {},
+   "source": [
+    "## Step 6 — Regression comparison\n",
+    "\n",
+    "The harness pays for itself when you change something. Run the same cases against a second variant and\n",
+    "diff the results — this is the check you put in CI so a prompt tweak can't silently degrade quality."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c3d0fb28",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T05:31:11.744800Z",
+     "iopub.status.busy": "2026-08-01T05:31:11.744254Z",
+     "iopub.status.idle": "2026-08-01T05:31:11.759265Z",
+     "shell.execute_reply": "2026-08-01T05:31:11.755867Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== variant b ===\n",
+      "deterministic: 1/3 passed | judge calls: 1 (saved 2) | avg judged score: 4.5\n",
+      "  FAIL billing_refund  \n",
+      "        - grade_category: expected 'billing', got 'other'\n",
+      "  FAIL login_2fa       \n",
+      "        - grade_valid_json: invalid JSON: Expecting value\n",
+      "        - grade_schema: unparseable\n",
+      "        - grade_category: unparseable\n",
+      "  PASS bug_export       score=4.5\n",
+      "GATE: FAIL ❌\n",
+      "\n",
+      "=== baseline vs candidate ===\n",
+      "deterministic: 3/3 -> 1/3\n",
+      "avg judged:    4.5 -> 4.5\n",
+      "REGRESSED cases: ['billing_refund', 'login_2fa']\n",
+      "VERDICT: do not ship ❌\n"
+     ]
+    }
+   ],
+   "source": [
+    "candidate = evaluate(\"b\")\n",
+    "report(candidate)\n",
+    "\n",
+    "print(\"\\n=== baseline vs candidate ===\")\n",
+    "print(f\"deterministic: {baseline['det_pass']}/{baseline['total']} -> {candidate['det_pass']}/{candidate['total']}\")\n",
+    "print(f\"avg judged:    {baseline['avg_score']} -> {candidate['avg_score']}\")\n",
+    "regressions = [r[\"case\"] for r in candidate[\"rows\"] if r[\"failures\"]]\n",
+    "if regressions:\n",
+    "    print(\"REGRESSED cases:\", regressions)\n",
+    "    print(\"VERDICT: do not ship ❌\")\n",
+    "else:\n",
+    "    print(\"VERDICT: no regressions ✅\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "05913fc6",
+   "metadata": {},
+   "source": [
+    "## Recap\n",
+    "\n",
+    "An evaluation harness doesn't have to be heavy to be useful:\n",
+    "\n",
+    "1. **Write cases with machine-checkable expectations** — then most grading is free.\n",
+    "2. **Tier 1: deterministic graders** catch format, schema, label, and content errors at zero token cost.\n",
+    "3. **Tier 2: an LLM judge on Grok** rates only what genuinely needs judgment — with a strict rubric,\n",
+    "   `temperature=0`, and a required reason.\n",
+    "4. **Short-circuit** — never spend a judge call on output that already failed an objective check.\n",
+    "5. **Compare variants** to turn \"seems better\" into a number, and gate your releases on it.\n",
+    "\n",
+    "**Next steps:** set `XAI_API_KEY` (see `.env.example`) and re-run to evaluate live Grok output with a\n",
+    "real Grok judge. From there: add cases every time you find a bug (that's how the suite grows where it\n",
+    "matters), and wire the gate into CI."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/registry.yaml
+++ b/registry.yaml
@@ -82,3 +82,15 @@
     - Zhaohan Dong
   tags:
     - function-calling
+- title: "Evaluating Grok Applications: Deterministic Checks + LLM-as-Judge"
+  path: examples/evaluating_grok_applications/guide.ipynb
+  date: 2026-07-24
+  description: "Build an eval harness for a Grok app: zero-token deterministic graders for schema, labels and content, an LLM-as-judge on Grok for subjective quality, short-circuiting to keep costs down, plus a regression gate between two variants"
+  authors:
+    - Anton Dzyatkovsky
+  tags:
+    - evaluation
+    - llm-as-judge
+    - testing
+    - structured-outputs
+    - reliability


### PR DESCRIPTION
## Description
Summary:
- Adds `examples/evaluating_grok_applications/guide.ipynb` — a compact but complete **evaluation harness** for a Grok application, built around a two-tier judging strategy:
  - **Tier 1 — deterministic graders (0 tokens):** valid JSON, schema/enum conformance, expected label, required & forbidden content.
  - **Tier 2 — LLM-as-judge on Grok:** scores only genuinely subjective qualities (helpfulness, tone) against a strict rubric at `temperature=0`, and must return a reason.
  - **Short-circuit:** if a deterministic check fails, the judge is never called — no paying to rate the tone of malformed output.
- Adds a **pass/fail gate** and a **regression comparison** between two variants (the kind of check you wire into CI).
- Registers the notebook in `registry.yaml`.

Why this change matters:
- There is currently no evaluation example in the cookbook, yet "did my prompt change make this better or worse?" is the question every team hits right after their first working demo. This gives a runnable answer.
- The two-tier + short-circuit pattern is what keeps eval suites affordable as they grow: most regressions (broken JSON, wrong label, missing content) are caught for free, and model calls are spent only where human-like judgment is actually required. The notebook demonstrates this concretely — the regressed variant uses 1 judge call instead of 3.
- Runs **end-to-end out of the box**: with `XAI_API_KEY` it evaluates live Grok output with a real Grok judge; without a key it runs a clearly-labeled offline demo so the graders, gate, and regression diff still execute for real.

## Type(s) of Change
- [x] New Content
- [ ] Content Improvement (e.g., enhancing existing content)
- [ ] Bug Fix
- [ ] Other

## Checklist
- [x] Read "How to Contribute" in `CONTRIBUTING.md`
- [x] Code follows style guidelines in "How to Contribute"
- [x] Included relevant dependencies
- [x] API key is not in committed files
- [x] Notebook runs end-to-end with cell outputs shown and no errors (verified with `pytest --nbmake`)
- [x] Added new notebook entry to `registry.yaml` (if PR adds a new notebook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)